### PR TITLE
added: cellar stats component

### DIFF
--- a/src/components/CellarStats.tsx
+++ b/src/components/CellarStats.tsx
@@ -1,0 +1,37 @@
+import { VFC } from 'react'
+import { Heading, HStack, StackProps, VStack } from '@chakra-ui/react'
+import { CardDivider } from './_layout/CardDivider'
+import { CardHeading } from './_typography/CardHeading'
+
+interface CellarStatsProps extends StackProps {
+  tvm: string
+  apy: string
+  trending: 'up' | 'down'
+}
+
+export const CellarStats: VFC<CellarStatsProps> = ({
+  tvm,
+  apy,
+  trending,
+  ...rest
+}) => {
+  const apyColor =
+    trending === 'up' ? 'lime' : trending === 'down' ? 'sunsetOrange' : ''
+
+  return (
+    <HStack spacing={8} divider={<CardDivider />} {...rest}>
+      <VStack spacing={1} align='flex-start'>
+        <Heading as='span' fontSize='3xl' fontWeight='bold'>
+          {tvm}
+        </Heading>
+        <CardHeading>TVM</CardHeading>
+      </VStack>
+      <VStack spacing={1} align='flex-start'>
+        <Heading as='span' fontSize='3xl' fontWeight='bold' color={apyColor}>
+          {apy}%
+        </Heading>
+        <CardHeading>APY</CardHeading>
+      </VStack>
+    </HStack>
+  )
+}

--- a/src/components/_pages/PageCellar.tsx
+++ b/src/components/_pages/PageCellar.tsx
@@ -1,4 +1,4 @@
-import { Heading, HeadingProps, VStack } from '@chakra-ui/react'
+import { Button, Heading, HeadingProps, HStack, VStack } from '@chakra-ui/react'
 import Layout from 'components/Layout'
 import { PerformanceCard } from 'components/_cards/PerformanceCard'
 import { Section } from 'components/_layout/Section'
@@ -9,6 +9,8 @@ import { CellarPageProps } from 'pages/cellars/[id]'
 import { useGetCellarQuery } from 'generated/subgraph'
 import StrategyBreakdownCard from 'components/_cards/StrategyBreakdownCard'
 import CellarDetailsCard from 'components/_cards/CellarDetailsCard'
+import Link from 'components/Link'
+import { CellarStats } from 'components/CellarStats'
 
 const h2Styles: HeadingProps = {
   as: 'h2',
@@ -32,7 +34,23 @@ const PageCellar: VFC<CellarPageProps> = ({ data: staticData }) => {
   return (
     <Layout>
       <Section>
-        <Heading pb={12}>{name}</Heading>
+        <HStack spacing={4} pb={12} justify='space-between'>
+          <HStack spacing={4}>
+            <Link href='/'>
+              <Button
+                variant='outline'
+                color='white'
+                border='2px solid'
+                borderColor='warmPink'
+                _hover={{ bg: 'warmPink' }}
+              >
+                Back
+              </Button>
+            </Link>
+            <Heading>C{name}</Heading>
+          </HStack>
+          <CellarStats tvm='$1.60M USDC' apy='8.88' trending='up' />
+        </HStack>
         <VStack spacing={4} align='stretch'>
           <Heading {...h2Styles}>Your Portfolio</Heading>
           <PortfolioCard />

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -53,6 +53,7 @@ const darkPlum = '#322436'
 const violentViolet = '#39196d'
 const energyYellow = '#F7DF58'
 const sunsetOrange = '#f26057'
+const lime = '#D4EC8D'
 const black = '#1f1f2d'
 const offBlack = '#1f1f1d'
 const white = '#FFFFFF'
@@ -129,6 +130,7 @@ export const colors = {
   violentViolet,
   energyYellow,
   sunsetOrange,
+  lime,
   warmPink,
   burntPink,
   aubergine,


### PR DESCRIPTION
## Description

This PR adds a new cellar stats component to the cellar page header.

## Changes

List any technical changes.

- [ ] added new `lime` color
- [ ] added `CellarStats` component

## Screenshots (if appropriate):

<img width="842" alt="image" src="https://user-images.githubusercontent.com/25848639/161863358-f6bb7965-9eb2-4f0f-ac99-9545db46edad.png">