### PR TITLE
added: tooltips to card stats

### DIFF
--- a/src/components/CardStat.tsx
+++ b/src/components/CardStat.tsx
@@ -1,48 +1,41 @@
-import { VFC } from "react"
+import { ReactNode, VFC } from "react"
 import {
   Flex,
   HStack,
   Icon,
   StackProps,
+  Tooltip,
   VStack,
 } from "@chakra-ui/react"
 import { CardHeading } from "./_typography/CardHeading"
 
 interface CardStatProps extends StackProps {
-  label: string
-  labelIcon?: any
+  label?: ReactNode
+  tooltip?: ReactNode
   statIcon?: any
 }
 
 export const CardStat: VFC<CardStatProps> = ({
   label,
-  labelIcon,
+  tooltip,
   statIcon,
   children,
   ...rest
 }) => {
   return (
     <VStack flex={1} align="flex-start" {...rest}>
-      <CardHeading>
-        {label}
-        {labelIcon && (
-          <>
-            {" "}
-            <Icon boxSize={3} />
-          </>
-        )}
-      </CardHeading>
+      <Tooltip label={tooltip} placement="top">
+        <HStack align="center">
+          <CardHeading>{label}</CardHeading>
+          {tooltip && (
+            <>
+              {" "}
+              <Icon color="text.body.lightMuted" boxSize={3} />
+            </>
+          )}
+        </HStack>
+      </Tooltip>
       <HStack spacing={1} align="center">
-        {statIcon && (
-          <Icon
-            boxSize={5}
-            color="text.body.dark"
-            bg="white"
-            p={1}
-            borderRadius="50%"
-            as={statIcon}
-          />
-        )}
         <Flex
           align="center"
           whiteSpace="nowrap"

--- a/src/components/_cards/CellarDetailsCard.tsx
+++ b/src/components/_cards/CellarDetailsCard.tsx
@@ -7,6 +7,7 @@ import {
   HStack,
   Icon,
   Text,
+  Tooltip,
   VStack,
 } from "@chakra-ui/react"
 import { CardDivider } from "components/_layout/CardDivider"
@@ -54,10 +55,16 @@ const CellarDetailsCard: VFC<BoxProps> = () => {
     <TransparentCard p={4} overflow="visible">
       <VStack spacing={4} divider={<CardDivider />} align="stretch">
         <CardStatRow align="flex-start">
-          <CardStat label="strategy type" labelIcon>
+          <CardStat
+            label="strategy type"
+            tooltip="Cellar uses Stablecoin lending"
+          >
             Stablecoin
           </CardStat>
-          <CardStat label="strategy assets">
+          <CardStat
+            label="strategy assets"
+            tooltip="Cellar will have exposure to 1 or more of these assets at any given time"
+          >
             <HStack spacing={-1.5}>
               {strategyAssets.map((asset) => {
                 const { src, alt, address } = asset
@@ -76,7 +83,10 @@ const CellarDetailsCard: VFC<BoxProps> = () => {
               })}
             </HStack>
           </CardStat>
-          <CardStat label="protocols">
+          <CardStat
+            label="protocols"
+            tooltip="Protocols in which Cellar operates"
+          >
             <AaveIcon
               color="violentViolet"
               bg="white"
@@ -86,7 +96,10 @@ const CellarDetailsCard: VFC<BoxProps> = () => {
             />
             AAVE
           </CardStat>
-          <CardStat label="mgmt fee">
+          <CardStat
+            label="mgmt fee"
+            tooltip="Platform management fee"
+          >
             <UsdcIcon
               color="violentViolet"
               bg="white"
@@ -97,9 +110,15 @@ const CellarDetailsCard: VFC<BoxProps> = () => {
             5%
           </CardStat>
           <VStack spacing={2} align="stretch">
-            <CardHeading>
-              performance split <Icon boxSize={3} />
-            </CardHeading>
+            <Tooltip
+              label="Cellar earned performance split"
+              placement="top-start"
+            >
+              <HStack align="center">
+                <CardHeading>performance split</CardHeading>
+                <Icon color="text.body.lightMuted" boxSize={3} />
+              </HStack>
+            </Tooltip>
             <Box w="100%" h="6px">
               {/* @ts-ignore */}
               <BarChart

--- a/src/components/_cards/PerformanceCard.tsx
+++ b/src/components/_cards/PerformanceCard.tsx
@@ -14,6 +14,7 @@ import { CardHeading } from "components/_typography/CardHeading"
 import { CardDivider } from "components/_layout/CardDivider"
 import { useNivoThemes } from "hooks/nivo"
 import TransparentCard from "./TransparentCard"
+import { CardStat } from "components/CardStat"
 const LineChart = dynamic(
   () => import("components/_charts/LineChart"),
   {
@@ -57,23 +58,34 @@ export const PerformanceCard: VFC<Props> = (props) => {
         <Box h="20rem">
           <HStack justify="space-between">
             <HStack spacing={8}>
-              <VStack align="flex-start">
-                <HStack spacing={1}>
-                  <Circle bg="deepSkyBlue.500" size={3} />
-                  <CardHeading>{timeline} cellar apy</CardHeading>
-                </HStack>
+              <CardStat
+                label={
+                  <HStack spacing={1}>
+                    <Circle bg="deepSkyBlue.500" size={3} />
+                    <CardHeading>{timeline} cellar apy</CardHeading>
+                  </HStack>
+                }
+                tooltip="Change in Cellar assets value in selected time period"
+              >
                 <Text fontSize="xl" fontWeight="bold">
                   50%
                 </Text>
-              </VStack>
+              </CardStat>
               <VStack align="flex-start">
-                <HStack spacing={1}>
-                  <Circle bg="sunsetOrange" size={3} />
-                  <CardHeading>{timeline} Volume</CardHeading>
-                </HStack>
-                <Text fontSize="xl" fontWeight="bold">
-                  12.25K USDC
-                </Text>
+                <CardStat
+                  label={
+                    <HStack>
+                      <Circle bg="sunsetOrange" size={3} />
+                      <CardHeading>{timeline} Volume</CardHeading>
+                    </HStack>
+                  }
+                  tooltip="The annual percentage yield in selected time period"
+                  spacing={1}
+                >
+                  <Text fontSize="xl" fontWeight="bold">
+                    12.25K USDC
+                  </Text>
+                </CardStat>
               </VStack>
             </HStack>
             <HStack

--- a/src/components/_cards/PortfolioCard.tsx
+++ b/src/components/_cards/PortfolioCard.tsx
@@ -29,10 +29,16 @@ export const PortfolioCard: VFC<BoxProps> = () => {
           templateColumns="repeat(2, max-content)"
           spacing={4}
         >
-          <CardStat label="net value" labelIcon="">
+          <CardStat
+            label="net value"
+            tooltip="Current value of your assets in Cellar"
+          >
             $0.00
           </CardStat>
-          <CardStat label="deposit assets">
+          <CardStat
+            label="deposit assets"
+            tooltip="Accepted deposit assets"
+          >
             <HStack spacing={-1.5}>
               {tokenConfig.map((token) => {
                 const { src, alt, address } = token
@@ -54,7 +60,10 @@ export const PortfolioCard: VFC<BoxProps> = () => {
               })}
             </HStack>
           </CardStat>
-          <CardStat label="apy" labelIcon="">
+          <CardStat
+            label="apy"
+            tooltip="APY earned on your Principal since initial investment from Strategy"
+          >
             0.00%
           </CardStat>
           <HStack>
@@ -67,7 +76,10 @@ export const PortfolioCard: VFC<BoxProps> = () => {
           spacing={4}
         >
           <VStack align="flex-start">
-            <CardStat label="available tokens">
+            <CardStat
+              label="available tokens"
+              tooltip="Unbonded LP tokens earn interest from strategy but do not earn Liquidity Mining rewards"
+            >
               <InlineImage
                 src="/assets/icons/aave.svg"
                 alt="aave logo"
@@ -77,7 +89,10 @@ export const PortfolioCard: VFC<BoxProps> = () => {
             <BondButton />
           </VStack>
           <VStack align="flex-start">
-            <CardStat label="bonded tokens">
+            <CardStat
+              label="bonded tokens"
+              tooltip="Unbonded LP tokens earn interest from strategy but do not earn Liquidity Mining rewards"
+            >
               <InlineImage
                 src="/assets/icons/aave.svg"
                 alt="aave logo"
@@ -88,7 +103,10 @@ export const PortfolioCard: VFC<BoxProps> = () => {
           </VStack>
         </SimpleGrid>
         <VStack align="flex-start">
-          <CardStat label="rewards">
+          <CardStat
+            label="rewards"
+            tooltip="Amount of SOMM earned and available to be claimed"
+          >
             <InlineImage
               src="/assets/icons/somm.svg"
               alt="aave logo"

--- a/src/components/_typography/CardHeading.tsx
+++ b/src/components/_typography/CardHeading.tsx
@@ -1,13 +1,16 @@
-import { Text, TextProps } from '@chakra-ui/react'
-import { VFC } from 'react'
+import { Text, TextProps, forwardRef } from "@chakra-ui/react"
+import { VFC } from "react"
 
-export const CardHeading: VFC<TextProps> = props => {
-  return (
-    <Text
-      textTransform='uppercase'
-      color='text.body.lightMuted'
-      fontSize='0.625rem'
-      {...props}
-    />
-  )
-}
+export const CardHeading: VFC<TextProps> = forwardRef(
+  (props, ref) => {
+    return (
+      <Text
+        ref={ref}
+        textTransform="uppercase"
+        color="text.body.lightMuted"
+        fontSize="0.625rem"
+        {...props}
+      />
+    )
+  }
+)


### PR DESCRIPTION
## Description

This PR introduces tooltips for the cellar view

## Changes

List any technical changes.

- [x] Refactored card stat component to accommodate tooltips
- [x] Added all tooltips from [this document](https://docs.google.com/spreadsheets/d/1fO28EFXJ4lC-BN2Q3leVEuR_izuMIgdYKjUrE0N2RKg/edit#gid=0)

## Screenshots (if appropriate):

<img width="861" alt="image" src="https://user-images.githubusercontent.com/25848639/166063060-5aa8d2e5-f974-4f6b-968d-36879ec1e45a.png">
