### PR TITLE
fixed: icon sizes

### DIFF
--- a/src/components/_menus/ModalMenu/Menu.tsx
+++ b/src/components/_menus/ModalMenu/Menu.tsx
@@ -42,7 +42,7 @@ export const Menu: VFC<MenuProps> = ({ value, onChange }) => {
       >
         {value ? (
           <HStack>
-            <Image src={value.src} alt={value.alt} />{" "}
+            <Image boxSize={5} src={value.src} alt={value.alt} />{" "}
             <span>{value.symbol}</span>
           </HStack>
         ) : (
@@ -73,7 +73,7 @@ export const Menu: VFC<MenuProps> = ({ value, onChange }) => {
                 onClick={() => onChange(token)}
               >
                 <HStack>
-                  <Image src={src} alt={alt} />
+                  <Image boxSize={5} src={src} alt={alt} />
                   <span>{symbol}</span>
                 </HStack>
               </MenuItemOption>


### PR DESCRIPTION
## Description

This PR introduces a fix for the new token assets that weren't properly sized in the deposit select element.

## Screenshots (if appropriate):

<img width="408" alt="image" src="https://user-images.githubusercontent.com/25848639/166077136-48b73914-2e48-4a87-9e8a-b0f7506c05f3.png">
