### PR TITLE
Feature/display coin

### DIFF
--- a/src/components/TokenAssets.tsx
+++ b/src/components/TokenAssets.tsx
@@ -85,7 +85,9 @@ export const TokenAssets: VFC<TokenAssetsProps> = ({
           </Box>
         </Tooltip>
       </HStack>
-      <Text>{tokensCropped[tokensCropped.length - 1].symbol}</Text>
+      <Text as="span">
+        {tokensCropped[tokensCropped.length - 1].symbol}
+      </Text>
     </HStack>
   ) : (
     <HStack>
@@ -108,7 +110,7 @@ export const TokenAssets: VFC<TokenAssetsProps> = ({
           )
         })}
       </HStack>
-      <Text>{tokens[tokens.length - 1].symbol}</Text>
+      <Text as="span">{tokens[tokens.length - 1].symbol}</Text>
     </HStack>
   )
 }


### PR DESCRIPTION
## Description

This PR introduces a span that displays the last token's symbol in the array passed to `<TokenAssets />`.

## Screenshots (if appropriate):

<img width="321" alt="image" src="https://user-images.githubusercontent.com/25848639/166127547-aa7d8be1-8cc8-4f28-859a-48d0a9b6c04c.png">
