### PR TITLE
updated: bonding table styles and columns

### DIFF
--- a/src/components/_cards/BondingTableCard.tsx
+++ b/src/components/_cards/BondingTableCard.tsx
@@ -8,9 +8,13 @@ import {
   Td,
   TableContainer,
   TableProps,
+  Flex,
+  Text,
+  Box,
 } from "@chakra-ui/react"
 import TransparentCard from "./TransparentCard"
 import { TertiaryButton } from "components/_buttons/TertiaryButton"
+import { InlineImage } from "components/InlineImage"
 
 interface BondingTableCardProps extends TableProps {
   data?: any
@@ -21,23 +25,27 @@ interface BondingPeriod {
   amount: number
   value: 1.1 | 1.25 | 1.5
   checked?: boolean
+  canUnbond: boolean
 }
 
 const placeholderData: BondingPeriod[] = [
   {
     bondingPeriod: "14 Days",
-    amount: 2000.01,
+    amount: 20.01,
     value: 1.25,
+    canUnbond: false,
   },
   {
     bondingPeriod: "7 Days",
-    amount: 2063.99,
+    amount: 63.99,
     value: 1.1,
+    canUnbond: true,
   },
   {
     bondingPeriod: "21 Days",
-    amount: 4000,
+    amount: 40,
     value: 1.5,
+    canUnbond: false,
   },
 ]
 
@@ -48,46 +56,63 @@ const BondingTableCard: VFC<BondingTableCardProps> = ({
   return (
     <TransparentCard>
       <TableContainer>
-        <Table variant="unstyled" size="sm" {...rest}>
+        <Table variant="unstyled" {...rest}>
           <Thead>
-            <Tr
-              borderBottom="1px solid"
-              borderColor="text.body.lightMuted"
-              color="text.body.lightMuted"
-            >
+            <Tr color="text.body.lightMuted">
+              <Th fontSize={10} fontWeight="normal">
+                Bonded Tokens
+              </Th>
               <Th fontSize={10} fontWeight="normal">
                 Bonding Period
               </Th>
               <Th fontSize={10} fontWeight="normal">
-                Bonded Amount
+                Rewards
               </Th>
-              <Th fontSize={10} fontWeight="normal">
-                Unbond Tokens
-              </Th>
+              <Th />
             </Tr>
           </Thead>
           <Tbody>
             {placeholderData.map((data, i) => {
-              const { amount, bondingPeriod, value } = data
+              const { amount, bondingPeriod, value, canUnbond } = data
               return (
                 <Tr
                   borderBottom="1px solid"
-                  borderColor="text.body.lightMuted"
+                  borderColor="rgba(203, 198, 209, 0.25)"
                   key={i}
+                  _last={{
+                    border: "none",
+                  }}
                 >
-                  <Td>{bondingPeriod}</Td>
-                  <Td>{amount.toFixed(2)}</Td>
                   <Td>
-                    <TertiaryButton
-                      size="sm"
-                      onClick={() =>
-                        window.alert(
-                          `You've bonded for ${bondingPeriod}. You earned at a rate of ${value}x.`
-                        )
-                      }
+                    <Flex
+                      align="center"
+                      fontSize="21px"
+                      fontWeight={700}
                     >
-                      Unbond
-                    </TertiaryButton>
+                      <InlineImage
+                        src="/assets/icons/aave.svg"
+                        alt="Aave logo"
+                      />{" "}
+                      {amount.toFixed(2)}
+                    </Flex>
+                  </Td>
+                  <Td>{bondingPeriod}</Td>
+                  <Td>{value}x SOMM</Td>
+                  <Td>
+                    {canUnbond ? (
+                      <TertiaryButton
+                        size="sm"
+                        onClick={() =>
+                          window.alert(
+                            `You've bonded for ${bondingPeriod}. You earned at a rate of ${value}x.`
+                          )
+                        }
+                      >
+                        Unbond
+                      </TertiaryButton>
+                    ) : (
+                      <Box px={4}>Unbonding in N days</Box>
+                    )}
                   </Td>
                 </Tr>
               )


### PR DESCRIPTION
## Description

This PR updates styles and columns to mirror the explorations done in the [MVP Figma file](https://www.figma.com/file/va02KKDiF9kbSMmAc1ajdS/MVP?node-id=641%3A15438).

## Screenshots (if appropriate):

<img width="851" alt="image" src="https://user-images.githubusercontent.com/25848639/166130049-5de6b1a1-d70b-4d46-ade6-6d42778503a0.png">
