### PR TITLE
added: lpTokenDisabled boolean for portfolio buttons

### DIFF
--- a/src/components/_cards/PortfolioCard.tsx
+++ b/src/components/_cards/PortfolioCard.tsx
@@ -143,7 +143,7 @@ export const PortfolioCard: VFC<PortfolioCardProps> = ({
                   alt="aave logo"
                   boxSize={5}
                 />
-                {toEther(totalRewards?.toFixed())}
+                {toEther(totalRewards?.toFixed() || "0")}
               </CardStat>
             </VStack>
             <BaseButton


### PR DESCRIPTION
Fixes #227, #228

## Description

This PR fixes button disabled states and value formatting in the portfolio card.

## Screenshots:

<img width="1108" alt="image" src="https://user-images.githubusercontent.com/25848639/171965585-4c5bacfd-e288-4a5c-9a49-6b8e0060cdf5.png">
