### PR TITLE
fixed: validation logic for deposits

### DIFF
--- a/src/components/_menus/ModalMenu/Menu.tsx
+++ b/src/components/_menus/ModalMenu/Menu.tsx
@@ -167,7 +167,7 @@ export const Menu: VFC<MenuProps> = ({
                 v > 0 || "You must submit a positive amount.",
               lessThanBalance: (v) => {
                 return (
-                  v <
+                  v <=
                     parseFloat(
                       toEther(
                         selectedTokenBalance.data?.value || "",


### PR DESCRIPTION
Fixes #267 

## Description

This PR introduces a fix to the validation logic that was blocking max deposits.

## Screenshot:
<img width="619" alt="image" src="https://user-images.githubusercontent.com/25848639/176546298-07db9247-d760-4083-9892-9093989ec304.png">

gas fees are absurd right now, so couldn't fully test a deposit flow, but the UI is no longer blocking on a max deposit.