### PR TITLE
refactored components to pull in apy from cellarDataMap

### DIFF
--- a/src/components/_cards/CellarCard/index.tsx
+++ b/src/components/_cards/CellarCard/index.tsx
@@ -5,7 +5,7 @@ import {
 } from "./CellarCardDisplay"
 import { useGetCellarQuery } from "generated/subgraph"
 import { cellarDataMap } from "data/cellarDataMap"
-import { averageApy, averageTvlActive } from "utils/cellarApy"
+import { averageTvlActive } from "utils/cellarApy"
 import { BigNumber } from "bignumber.js"
 
 interface CellarCardProps extends BoxProps {
@@ -37,24 +37,31 @@ export const CellarCard: React.FC<CellarCardProps> = ({
 
   const { asset, dayDatas, tvlActive, tvlTotal } = data.cellar
 
-  const apy = data && averageApy(dayDatas).toFixed(2)
+  // const apy = data && averageApy(dayDatas).toFixed(2)
   const tvm =
     tvlTotal &&
     asset &&
     new BigNumber(tvlTotal).dividedBy(10 ^ asset?.decimals).toString()
 
   const avgTvlActive = averageTvlActive(dayDatas, tvlActive)
+  const {
+    name,
+    description,
+    apy,
+    strategyType,
+    managementFee,
+    protocols,
+  } = cellarDataMap[cellarAddress]
 
   const cellarCardData: CellarCardData = {
     cellarId: cellarAddress,
-    name: cellarDataMap[cellarAddress].name,
-    description: cellarDataMap[cellarAddress].description,
+    name,
+    description,
     tvm: "",
-    strategyType: cellarDataMap[cellarAddress].strategyType,
-    // managementFee: `${parseFloat(data.cellar.feePlatform) * 100}%`,
-    managementFee: cellarDataMap[cellarAddress].managementFee,
-    protocols: cellarDataMap[cellarAddress].protocols,
     apy,
+    strategyType,
+    managementFee,
+    protocols,
   }
 
   return <CellarCardDisplay data={cellarCardData} {...rest} />

--- a/src/components/_modals/DepositModal.tsx
+++ b/src/components/_modals/DepositModal.tsx
@@ -52,10 +52,21 @@ import { BaseModal } from "./BaseModal"
 import { getCurrentAsset } from "utils/getCurrentAsset"
 import { ExternalLinkIcon } from "components/_icons"
 import { analytics } from "utils/analytics"
+import { useRouter } from "next/router"
+import { useGetCellarQuery } from "generated/subgraph"
 
 type DepositModalProps = Pick<ModalProps, "isOpen" | "onClose">
 
 export const DepositModal: VFC<DepositModalProps> = (props) => {
+  const { query } = useRouter()
+  const { id } = query
+  const [{ data }, refetch] = useGetCellarQuery({
+    variables: {
+      cellarAddress: id as string,
+      cellarString: id as string,
+    },
+    pause: typeof id === "undefined",
+  })
   const methods = useForm<FormValues>()
   const {
     register,
@@ -221,6 +232,8 @@ export const DepositModal: VFC<DepositModalProps> = (props) => {
             stable: tokenSymbol,
             value: depositAmount,
           })
+          refetch()
+          props.onClose()
 
           update({
             heading: "ERC20 Approval",

--- a/src/components/_pages/PageCellar.tsx
+++ b/src/components/_pages/PageCellar.tsx
@@ -22,7 +22,6 @@ import { formatCurrentDeposits } from "utils/formatCurrentDeposits"
 import { ArrowLeftIcon } from "components/_icons"
 import { BreadCrumb } from "components/BreadCrumb"
 import { cellarDataMap } from "data/cellarDataMap"
-import { averageApy } from "utils/cellarApy"
 import { getCalulatedTvl } from "utils/bigNumber"
 import { PerformanceChartProvider } from "context/performanceChartContext"
 import BigNumber from "bignumber.js"
@@ -57,7 +56,7 @@ const PageCellar: VFC<CellarPageProps> = ({ data: staticData }) => {
 
   const calculatedTvl = tvlTotal && getCalulatedTvl(tvlTotal, 18)
   const tvmVal = formatCurrency(calculatedTvl)
-  const apy = data && averageApy(dayDatas!).toFixed(2)
+  // const apy = data && averageApy(dayDatas!).toFixed(2)
   const currentDepositsVal = formatCurrentDeposits(
     addedLiquidityAllTime,
     removedLiquidityAllTime
@@ -65,7 +64,7 @@ const PageCellar: VFC<CellarPageProps> = ({ data: staticData }) => {
   const cellarCap =
     liquidityLimit &&
     new BigNumber(liquidityLimit).dividedBy(10 ** 6).toString()
-  const { name: nameAbbreviated } = cellarDataMap[id]
+  const { name: nameAbbreviated, apy } = cellarDataMap[id]
 
   return (
     <Layout>

--- a/src/data/cellarDataMap.ts
+++ b/src/data/cellarDataMap.ts
@@ -4,6 +4,7 @@ export interface CellarDataMap {
     description: string
     strategyType: string
     managementFee: string
+    apy: string
     protocols: string
     supportedChains: string[]
     performanceSplit: {
@@ -22,6 +23,7 @@ export const cellarDataMap: CellarDataMap = {
       "The Aave stablecoin strategy aims to select the optimal stablecoin lending position available to lend across Aave markets on a continuous basis.",
     strategyType: "Stablecoin",
     managementFee: "1%",
+    apy: "1.5",
     protocols: "AAVE",
     supportedChains: [
       "DAI",


### PR DESCRIPTION
Fixes #52

## Description

Updated APY values to pull in hardcoded value from `cellarDataMap` instead of the subgraph.

## Changes

List any technical changes.

- [ ] added `apy` to `cellarDataMap` and related interface
- [ ] refactored components to pull in `apy` from that `cellarDataMap`

## Screenshots:
<img width="257" alt="image" src="https://user-images.githubusercontent.com/25848639/177609137-ab727ef3-29ae-434a-9dbe-4b97e678feb9.png">
<img width="415" alt="image" src="https://user-images.githubusercontent.com/25848639/177609215-2eacf633-a215-4db3-a23e-9927d2e17ede.png">
