### PR TITLE
Change default slippage and add slippage config

### DIFF
--- a/src/components/_cards/SwapSettingsCard.tsx
+++ b/src/components/_cards/SwapSettingsCard.tsx
@@ -1,0 +1,51 @@
+import { VFC } from "react"
+import { Box, Flex, Input } from "@chakra-ui/react"
+import { CardHeading } from "components/_typography/CardHeading"
+import { config } from "utils/config"
+import { useFormContext } from "react-hook-form"
+
+export const SwapSettingsCard: VFC = () => {
+  const { register } = useFormContext()
+
+  return (
+    <Box
+      w={150}
+      px={6}
+      py={4}
+      position="absolute"
+      top={-4}
+      right={37}
+      zIndex="999"
+      bg="surface.bg"
+      color="neutral.100"
+      border="1px solid"
+      borderColor="white"
+      borderRadius={24}
+    >
+      <CardHeading fontSize="0.7rem">slippage tolerance</CardHeading>
+      <Flex alignItems="center">
+        <Input
+          variant="unstyled"
+          type="number"
+          step="any"
+          placeholder={config.SWAP.SLIPPAGE.toString()}
+          fontSize="md"
+          fontWeight={700}
+          textAlign="right"
+          mr={1}
+          {...register("slippage", {
+            required: "Enter slippage tolerance.",
+            valueAsNumber: true,
+            validate: {
+              positive: (v) =>
+                v >= 0 || "Enter a valid slippage percentage.",
+              lessThanOrEqualToFiftyPercent: (v) =>
+                v <= 50 || "Enter a valid slippage percentage.",
+            },
+          })}
+        />
+        %
+      </Flex>
+    </Box>
+  )
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -6,7 +6,8 @@ import { erc20ABI } from "wagmi"
 /** Ensure Checksum Address  */
 export const config = {
   SWAP: {
-    SLIPPAGE: 5,
+    // Do not set to a value less than 0.01.
+    SLIPPAGE: 0.5,
   },
   CONTRACT: {
     AAVE_V2_STABLE_CELLAR: {


### PR DESCRIPTION
## Description

Sets a default slippage value for Uniswap swaps through the `CellarRouter` and adds the option for users to change the slippage tolerance through the UI.

## Changes

- [x] Change default slippage from 5% to 0.5%
- [x] Add button to change slippage tolerance.

## Screenshots (if appropriate):

<img width="438" alt="07-11-2022 @ 06 03 PM@2x" src="https://user-images.githubusercontent.com/20782088/178328761-218967bf-ee5c-467c-80ac-b9938dac9a21.png">