### PR TITLE
change default selected deposit token to active asset

### DIFF
--- a/src/components/TokenAssets/index.tsx
+++ b/src/components/TokenAssets/index.tsx
@@ -1,6 +1,6 @@
 import { StackProps } from "@chakra-ui/react"
-import { Token } from "data/tokenConfig"
-import { useMemo, VFC } from "react"
+import { Token, tokenConfig } from "data/tokenConfig"
+import { VFC } from "react"
 import { CroppedMap } from "./TokenMaps/CroppedMap"
 import { UncroppedMap } from "./TokenMaps/UncroppedMap"
 
@@ -16,33 +16,15 @@ export const TokenAssets: VFC<TokenAssetsProps> = ({
   displaySymbol,
   ...rest
 }) => {
-  // set active strategy asset as first in tokens array
-  const rearrangedTokens = useMemo(() => {
-    const activeIndex = tokens.findIndex(
-      (token) =>
-        token.address.toUpperCase() === activeAsset.toUpperCase()
-    )
-
-    if (activeIndex < 1) {
-      return tokens
-    }
-
-    return [
-      tokens[activeIndex],
-      ...tokens.slice(0, activeIndex),
-      ...tokens.slice(activeIndex + 1),
-    ]
-  }, [tokens, activeAsset])
-
-  return rearrangedTokens.length > 6 ? (
+  return tokenConfig.length > 6 ? (
     <CroppedMap
-      tokens={rearrangedTokens}
+      tokens={tokenConfig}
       displaySymbol={displaySymbol}
       {...rest}
     />
   ) : (
     <UncroppedMap
-      tokens={rearrangedTokens}
+      tokens={tokenConfig}
       displaySymbol={displaySymbol}
       {...rest}
     />

--- a/src/components/_menus/ModalMenu/Menu.tsx
+++ b/src/components/_menus/ModalMenu/Menu.tsx
@@ -110,7 +110,7 @@ export const Menu: VFC<MenuProps> = ({
           w={menuDims?.borderBox.width}
         >
           <MenuOptionGroup
-            defaultValue={tokenConfig[0].symbol}
+            defaultValue={activeAsset && tokenConfig[0].symbol}
             type="radio"
           >
             {tokenConfig.map((token) => {
@@ -118,6 +118,9 @@ export const Menu: VFC<MenuProps> = ({
               const isActiveAsset =
                 token.address.toUpperCase() ===
                 activeAsset?.toUpperCase()
+
+              // Set default selected token to active asset.
+              if (isActiveAsset && !value) onChange(token)
 
               return (
                 <MenuItemOption

--- a/src/components/_modals/DepositModal.tsx
+++ b/src/components/_modals/DepositModal.tsx
@@ -436,6 +436,21 @@ export const DepositModal: VFC<DepositModalProps> = (props) => {
   const { activeAsset } = cellarData || {}
   const currentAsset = getCurrentAsset(tokenConfig, activeAsset)
 
+  // Move active asset to top of token list.
+  useEffect(() => {
+    if (currentAsset == undefined) return
+
+    const indexOfActiveAsset = tokenConfig.findIndex(
+      (token) => token === currentAsset
+    )
+
+    tokenConfig.splice(
+      0,
+      0,
+      tokenConfig.splice(indexOfActiveAsset, 1)[0]
+    )
+  }, [activeAsset, currentAsset])
+
   // Close swap settings card if user changed current asset to active asset.
   useEffect(() => {
     if (selectedToken?.address === currentAsset?.address)


### PR DESCRIPTION
## Description

Changes the default selected token in the deposit modal to the cellar's active asset.

## Changes

List any technical changes.

- [x] Changes the default selected token to the active asset.
- [x] Moved the active asset to the top of the token list.
- [x] No longer ask user to select a token when default token is selected.

## Screenshots (if appropriate):

### Before:
![07-12-2022 @ 06 32 AM](https://user-images.githubusercontent.com/20782088/178424019-c909ef6e-6d93-4393-8e90-56c146fab811.gif)

### After:
![07-12-2022 @ 06 28 AM](https://user-images.githubusercontent.com/20782088/178423711-85ae5265-4cb4-43e1-b288-b4f0c273fad2.gif)