### PR TITLE
Deposit limit

### DIFF
--- a/src/components/_menus/ModalMenu/Menu.tsx
+++ b/src/components/_menus/ModalMenu/Menu.tsx
@@ -22,6 +22,8 @@ import { useFormContext } from "react-hook-form"
 import { toEther } from "utils/formatCurrency"
 import { ModalMenuProps } from "."
 import { analytics } from "utils/analytics"
+import { useGetCurrentDepositsQuery } from "generated/subgraph"
+import { useAccount } from "wagmi"
 
 export interface MenuProps
   extends Omit<ModalMenuProps, "setSelectedToken"> {
@@ -35,6 +37,10 @@ export const Menu: VFC<MenuProps> = ({
   value,
   onChange,
 }) => {
+  const [{ data: account }] = useAccount()
+  const [{ data: depositData }] = useGetCurrentDepositsQuery({
+    variables: { walletAddress: account?.address.toLowerCase()! },
+  })
   const { colors } = useTheme()
   const menuRef = useRef(null)
   const menuDims = useDimensions(menuRef, true)
@@ -181,6 +187,15 @@ export const Menu: VFC<MenuProps> = ({
                     ) || "Insufficient balance"
                 )
               },
+              depositLimit: () =>
+                parseFloat(
+                  toEther(
+                    depositData?.wallet?.currentDeposits!,
+                    18,
+                    false
+                  )
+                ) > 50000 ||
+                "You cannot submit more total funds than the cellar limit of $50,0000",
             },
           })}
         />

--- a/src/components/_menus/ModalMenu/Menu.tsx
+++ b/src/components/_menus/ModalMenu/Menu.tsx
@@ -187,13 +187,14 @@ export const Menu: VFC<MenuProps> = ({
                     ) || "Insufficient balance"
                 )
               },
-              depositLimit: () =>
+              depositLimit: (v) =>
                 parseFloat(
-                  toEther(
-                    depositData?.wallet?.currentDeposits!,
-                    18,
-                    false
-                  )
+                  v +
+                    toEther(
+                      depositData?.wallet?.currentDeposits!,
+                      18,
+                      false
+                    )
                 ) > 50000 ||
                 "You cannot submit more total funds than the cellar limit of $50,0000",
             },

--- a/src/components/_menus/ModalMenu/Menu.tsx
+++ b/src/components/_menus/ModalMenu/Menu.tsx
@@ -187,16 +187,17 @@ export const Menu: VFC<MenuProps> = ({
                     ) || "Insufficient balance"
                 )
               },
-              depositLimit: (v) =>
-                parseFloat(
-                  v +
-                    toEther(
-                      depositData?.wallet?.currentDeposits!,
-                      18,
-                      false
-                    )
-                ) > 50000 ||
-                "You cannot submit more total funds than the cellar limit of $50,0000",
+              depositLimit: (v) => {
+                const currentDeposits = toEther(
+                  depositData?.wallet?.currentDeposits!,
+                  18,
+                  false
+                )
+                return (
+                  parseFloat(v + currentDeposits) > 50000 ||
+                  `You cannot exceed the cellar limit of $50,0000. You currently have ${currentDeposits} deposited in this cellar.`
+                )
+              },
             },
           })}
         />

--- a/src/components/_modals/DepositModal.tsx
+++ b/src/components/_modals/DepositModal.tsx
@@ -56,10 +56,7 @@ import { getCurrentAsset } from "utils/getCurrentAsset"
 import { ExternalLinkIcon } from "components/_icons"
 import { analytics } from "utils/analytics"
 import { useRouter } from "next/router"
-import {
-  useGetCellarQuery,
-  useGetCurrentDepositsQuery,
-} from "generated/subgraph"
+import { useGetCellarQuery } from "generated/subgraph"
 import { SwapSettingsCard } from "components/_cards/SwapSettingsCard"
 
 type DepositModalProps = Pick<ModalProps, "isOpen" | "onClose">
@@ -136,13 +133,6 @@ export const DepositModal: VFC<DepositModalProps> = (props) => {
     token: selectedToken?.address,
     formatUnits: "wei",
   })
-
-  // TODO: complete writing form validation based on this query
-  const [{ data: depositData }] = useGetCurrentDepositsQuery({
-    variables: { walletAddress: account?.address.toLowerCase()! },
-  })
-
-  console.log({ depositData, account })
 
   const erc20Contract =
     selectedToken?.address &&

--- a/src/components/_modals/DepositModal.tsx
+++ b/src/components/_modals/DepositModal.tsx
@@ -56,7 +56,10 @@ import { getCurrentAsset } from "utils/getCurrentAsset"
 import { ExternalLinkIcon } from "components/_icons"
 import { analytics } from "utils/analytics"
 import { useRouter } from "next/router"
-import { useGetCellarQuery } from "generated/subgraph"
+import {
+  useGetCellarQuery,
+  useGetCurrentDepositsQuery,
+} from "generated/subgraph"
 import { SwapSettingsCard } from "components/_cards/SwapSettingsCard"
 
 type DepositModalProps = Pick<ModalProps, "isOpen" | "onClose">
@@ -133,6 +136,12 @@ export const DepositModal: VFC<DepositModalProps> = (props) => {
     token: selectedToken?.address,
     formatUnits: "wei",
   })
+
+  const [{ data: depositData }] = useGetCurrentDepositsQuery({
+    variables: { walletAddress: account?.address! },
+  })
+
+  console.log({ depositData, account })
 
   const erc20Contract =
     selectedToken?.address &&

--- a/src/components/_modals/DepositModal.tsx
+++ b/src/components/_modals/DepositModal.tsx
@@ -139,7 +139,7 @@ export const DepositModal: VFC<DepositModalProps> = (props) => {
 
   // TODO: complete writing form validation based on this query
   const [{ data: depositData }] = useGetCurrentDepositsQuery({
-    variables: { walletAddress: account?.address! },
+    variables: { walletAddress: account?.address.toLowerCase()! },
   })
 
   console.log({ depositData, account })

--- a/src/components/_modals/DepositModal.tsx
+++ b/src/components/_modals/DepositModal.tsx
@@ -137,6 +137,7 @@ export const DepositModal: VFC<DepositModalProps> = (props) => {
     formatUnits: "wei",
   })
 
+  // TODO: complete writing form validation based on this query
   const [{ data: depositData }] = useGetCurrentDepositsQuery({
     variables: { walletAddress: account?.address! },
   })

--- a/src/generated/subgraph.ts
+++ b/src/generated/subgraph.ts
@@ -1756,6 +1756,13 @@ export type GetCellarQueryVariables = Exact<{
 
 export type GetCellarQuery = { __typename?: 'Query', cellar?: { __typename?: 'Cellar', id: string, liquidityLimit: string, name: string, numWalletsActive: number, numWalletsAllTime: number, tvlActive: string, tvlInactive: string, tvlTotal: string, addedLiquidityAllTime: string, removedLiquidityAllTime: string, asset: { __typename?: 'TokenERC20', symbol: string, decimals: number }, dayDatas: Array<{ __typename?: 'CellarDayData', id: string, date: number, tvlActive: string, tvlInvested: string, earnings: string }> } | null, wallets: Array<{ __typename?: 'Wallet', id: string, cellarShares: Array<{ __typename?: 'CellarShare', id: string, balance: string }>, depositWithdrawEvents: Array<{ __typename?: 'DepositWithdrawEvent', id: string, txId: string, amount: string }> }> };
 
+export type GetCurrentDepositsQueryVariables = Exact<{
+  walletAddress: Scalars['ID'];
+}>;
+
+
+export type GetCurrentDepositsQuery = { __typename?: 'Query', wallet?: { __typename?: 'Wallet', id: string, currentDeposits: string } | null };
+
 export type GetHourlyTvlQueryVariables = Exact<{
   epoch?: InputMaybe<Scalars['Int']>;
 }>;
@@ -1900,6 +1907,18 @@ export const GetCellarDocument = gql`
 
 export function useGetCellarQuery(options: Omit<Urql.UseQueryArgs<GetCellarQueryVariables>, 'query'>) {
   return Urql.useQuery<GetCellarQuery>({ query: GetCellarDocument, ...options });
+};
+export const GetCurrentDepositsDocument = gql`
+    query GetCurrentDeposits($walletAddress: ID!) {
+  wallet(id: $walletAddress) {
+    id
+    currentDeposits
+  }
+}
+    `;
+
+export function useGetCurrentDepositsQuery(options: Omit<Urql.UseQueryArgs<GetCurrentDepositsQueryVariables>, 'query'>) {
+  return Urql.useQuery<GetCurrentDepositsQuery>({ query: GetCurrentDepositsDocument, ...options });
 };
 export const GetHourlyTvlDocument = gql`
     query GetHourlyTVL($epoch: Int) {

--- a/src/queries/get-current-deposits.graphql
+++ b/src/queries/get-current-deposits.graphql
@@ -1,0 +1,6 @@
+query GetCurrentDeposits($walletAddress: ID!) {
+  wallet(id: $walletAddress) {
+    id
+    currentDeposits
+  }
+}


### PR DESCRIPTION
Fixes #239 

## Description

This PR introduces the validation logic to make sure a user's current balance is below the cellar deposit limit.

## Changes

- [ ] Added gql query to grab current deposits from given wallet address
- [ ] Added a `depositLimit` validation rule to the deposit modal (checks the sum of the passed value from the form input + the wallet's current deposits against the limit of 50,000 for the cellar)
