### PR TITLE
fixed cellar cap

### DIFF
--- a/src/components/CellarStats.tsx
+++ b/src/components/CellarStats.tsx
@@ -1,7 +1,8 @@
-import { VFC } from "react"
+import { ReactNode, VFC } from "react"
 import {
   Box,
   HStack,
+  Spinner,
   StackProps,
   Text,
   Tooltip,
@@ -17,7 +18,7 @@ import { analytics } from "utils/analytics"
 import { debounce } from "lodash"
 
 interface CellarStatsProps extends StackProps {
-  tvm?: string
+  tvm?: ReactNode
   apy?: string
   apyTooltip?: string
   currentDeposits?: string
@@ -58,7 +59,7 @@ export const CellarStats: VFC<CellarStatsProps> = ({
     >
       <VStack spacing={1} align="flex-start">
         <Text as="span" fontSize="21px" fontWeight="bold">
-          {tvm}
+          {tvm !== "$undefined" ? tvm : <Spinner />}
         </Text>
         <Tooltip
           hasArrow

--- a/src/components/_pages/PageCellar.tsx
+++ b/src/components/_pages/PageCellar.tsx
@@ -4,6 +4,7 @@ import {
   Heading,
   HeadingProps,
   HStack,
+  Spinner,
   VStack,
 } from "@chakra-ui/react"
 import { Layout } from "components/Layout"
@@ -59,6 +60,7 @@ const PageCellar: VFC<CellarPageProps> = ({ data: staticData }) => {
     liquidityLimit,
     addedLiquidityAllTime,
     removedLiquidityAllTime,
+    asset,
   } = cellar || {}
   const { activeAsset } = cellarData || {}
   const [cellarShareBalance, setCellarSharesBalance] =
@@ -98,7 +100,7 @@ const PageCellar: VFC<CellarPageProps> = ({ data: staticData }) => {
   const cellarCap =
     liquidityLimit &&
     new BigNumber(liquidityLimit)
-      .dividedBy(10 ** userData?.balances?.aAsset?.decimals)
+      .dividedBy(10 ** (asset?.decimals || 0))
       .toString()
   const { name: nameAbbreviated, cellarApy } = cellarDataMap[id]
   const activeSymbol =
@@ -150,7 +152,7 @@ const PageCellar: VFC<CellarPageProps> = ({ data: staticData }) => {
             </HStack>
           </VStack>
           <CellarStats
-            tvm={`$${tvmVal} ${activeSymbol}`}
+            tvm={tvmVal ? `$${tvmVal} ${activeSymbol}` : <Spinner />}
             apy={expectedApy.toFixed(1)}
             apyTooltip={apyLabel}
             currentDeposits={currentDepositsVal}


### PR DESCRIPTION
Fixes #367

## Description

This PR fixes the logic used to calculate the cellar cap value.

## Changes

List any technical changes.

- [ ] using sg asset instead of userData active asset
- [ ] added spinner to tvm while value is being loaded

## Screenshot:

<img width="868" alt="image" src="https://user-images.githubusercontent.com/25848639/180326002-81aa6377-c4ae-4452-a2c8-081f2da31561.png">
