### PR TITLE
Performance fee

### DIFF
--- a/src/components/_cards/CellarDetailsCard.tsx
+++ b/src/components/_cards/CellarDetailsCard.tsx
@@ -66,6 +66,15 @@ const CellarDetailsCard: VFC<CellarDetailsProps> = ({
   const { cellarData } = useAaveV2Cellar()
   const { activeAsset } = cellarData
 
+  // Unsure why this was necessary? Nivo acts strangely when there are fewer than three args in an index. Could be refined later.
+  const moveColors = (colorTheme: string[]): string[] => {
+    const lastColor = colorTheme.slice(-1)
+    const otherColors = colorTheme.slice(0, -1)
+    return [...lastColor, ...otherColors]
+  }
+
+  const colors = moveColors(barChartTheme)
+
   return (
     <TransparentCard p={8} overflow="visible">
       <VStack spacing={8} align={{ sm: "unset", md: "stretch" }}>
@@ -149,7 +158,7 @@ const CellarDetailsCard: VFC<CellarDetailsProps> = ({
               {/* @ts-ignore */}
               <BarChart
                 layout="horizontal"
-                colors={barChartTheme}
+                colors={colors}
                 borderColor={theme.colors.neutral[800]}
                 borderWidth={1}
                 borderRadius={2}

--- a/src/data/cellarDataMap.ts
+++ b/src/data/cellarDataMap.ts
@@ -45,8 +45,8 @@ export const cellarDataMap: CellarDataMap = {
       "GUSD",
     ],
     performanceSplit: {
-      "strategy provider": 5,
-      protocol: 5,
+      // "strategy provider": 5,
+      protocol: 10,
       depositors: 90,
     },
     strategyBreakdown: {

--- a/src/data/cellarDataMap.ts
+++ b/src/data/cellarDataMap.ts
@@ -45,7 +45,6 @@ export const cellarDataMap: CellarDataMap = {
       "GUSD",
     ],
     performanceSplit: {
-      // "strategy provider": 5,
       protocol: 10,
       depositors: 90,
     },


### PR DESCRIPTION
Fixes #361

## Description

This PR introduces changes to the performance split chart.

## Changes


- [ ] added a utility function to reorder theme array for chart? Was starting on the second value for some reason??
- [ ] adjusted the `cellarDataMap` to match requested changes

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/25848639/180576295-12c2fede-4a42-48f4-b00a-911552caa9c2.png)
