### PR TITLE
found solve for tvm chart vals

### DIFF
--- a/src/components/_charts/TVLChart.tsx
+++ b/src/components/_charts/TVLChart.tsx
@@ -6,6 +6,7 @@ import { useNivoThemes } from "hooks/nivo"
 import dynamic from "next/dynamic"
 import { FunctionComponent, VFC } from "react"
 import { debounce } from "lodash"
+import { formatCurrency } from "utils/formatCurrency"
 const LineChart = dynamic(
   () => import("components/_charts/LineChart"),
   {
@@ -34,7 +35,9 @@ export const TVLChart: VFC = () => {
   const updateTvl = ({ data: point, index }: Point) => {
     setTvl({
       xFormatted: point.xFormatted,
-      yFormatted: data?.series![0].data[index].y as string,
+      yFormatted: `
+        ${formatCurrency(data?.series![0].data[index].y as string)!} 
+        ${data?.series![0].data[index].asset.symbol}`,
     })
   }
   const debouncedTvl = debounce(updateTvl, 100)

--- a/src/context/performanceChartContext.tsx
+++ b/src/context/performanceChartContext.tsx
@@ -23,6 +23,11 @@ import { mutateDayData, mutateHourlyData } from "utils/urql"
 export interface DataProps {
   series?: Serie[]
   chartProps: Partial<LineProps>
+  asset?: {
+    decimals: number
+    symbol: string
+    __typename: string
+  }
 }
 
 export interface TvlData {

--- a/src/utils/urql.ts
+++ b/src/utils/urql.ts
@@ -4,16 +4,16 @@ import {
   GetAllTimeTvlQuery,
 } from "generated/subgraph"
 import { Serie } from "@nivo/line"
-import { formatCurrency } from "./formatCurrency"
 import { getCalulatedTvl } from "./bigNumber"
 
-const formatTvl = (tvlTotal: string, asset: any) => {
-  // const total = getCalulatedTvl(tvlTotal, asset?.decimals)
-  const total = getCalulatedTvl(tvlTotal, 18)
+// Unsed code. Keeping it in here in case we require it one day.
+// const formatTvl = (tvlTotal: string, asset: any) => {
+//   // const total = getCalulatedTvl(tvlTotal, asset?.decimals)
+//   const total = getCalulatedTvl(tvlTotal, 18)
 
-  const totalString = `${formatCurrency(total)} ${asset?.symbol}`
-  return totalString
-}
+//   const totalString = `${formatCurrency(total)} ${asset?.symbol}`
+//   return totalString
+// }
 
 export const mutateHourlyData = (
   data?: GetHourlyTvlQuery
@@ -26,7 +26,8 @@ export const mutateHourlyData = (
           ({ date, tvlTotal, asset }) => {
             return {
               x: new Date(date * 1000),
-              y: formatTvl(tvlTotal, asset),
+              y: getCalulatedTvl(tvlTotal, 18),
+              asset,
             }
           }
         ),
@@ -45,7 +46,8 @@ export const mutateDayData = (
         data: data.cellarDayDatas.map(({ date, tvlTotal, asset }) => {
           return {
             x: new Date(date * 1000),
-            y: formatTvl(tvlTotal, asset),
+            y: getCalulatedTvl(tvlTotal, 18),
+            asset,
           }
         }),
       },


### PR DESCRIPTION
Fixes #399

## Description

This PR introduces fix to bug that was causing nivo chart to represent 1mil as... 1 😅 

## Changes

- [ ] refactored code to not format values before they hit the Nivo chart
- [ ] removed unused formatting functions

## Screenshot:

<img width="819" alt="image" src="https://user-images.githubusercontent.com/25848639/181367892-96300e9a-cced-4669-9be4-e1aa21375872.png">
