### PR TITLE
clear errors on token select

### DIFF
--- a/src/components/_menus/ModalMenu/Menu.tsx
+++ b/src/components/_menus/ModalMenu/Menu.tsx
@@ -44,7 +44,7 @@ export const Menu: VFC<MenuProps> = ({
   const { colors } = useTheme()
   const menuRef = useRef(null)
   const menuDims = useDimensions(menuRef, true)
-  const { register, setValue } = useFormContext()
+  const { register, setValue, clearErrors } = useFormContext()
   const availableBalance = `${toEther(
     selectedTokenBalance?.data?.value,
     selectedTokenBalance?.data?.decimals
@@ -137,7 +137,10 @@ export const Menu: VFC<MenuProps> = ({
                   value={symbol}
                   borderRadius={8}
                   _hover={{ bg: "rgba(96, 80, 155, 0.4)" }}
-                  onClick={() => onChange(token)}
+                  onClick={() => {
+                    clearErrors()
+                    onChange(token)
+                  }}
                 >
                   <HStack justify="space-between">
                     <HStack>


### PR DESCRIPTION
Fixes #386

## Description

This PR introduces a `clearErrors()` step when a new token is selected in the deposit modal menu. It should resolve the insufficient funds bug.
