### PR TITLE
updated connect button copy

### DIFF
--- a/src/components/_buttons/ConnectButton/index.tsx
+++ b/src/components/_buttons/ConnectButton/index.tsx
@@ -119,7 +119,7 @@ const ConnectButton = ({
             ? `Unable to connect`
             : c.ready
             ? `Connect Wallet`
-            : `Please install MetaMask`}
+            : `Connect Wallet`}
         </BaseButton>
       )}
     </ClientOnly>


### PR DESCRIPTION
Fixes #407 

## Description

If the customer has not installed Metamask currently we show button names "Please install MetaMask".
As standard practice by others is also first to show “Connect wallet” and later point out or direct to install Metamask, we will change it the same way.
