### PR TITLE
feat(contracts): add more proper gasLimit

### DIFF
--- a/src/components/_cards/BondingTableCard.tsx
+++ b/src/components/_cards/BondingTableCard.tsx
@@ -53,7 +53,8 @@ const BondingTableCard: VFC<TableProps> = (props) => {
   const handleUnBond = async (id: number) => {
     analytics.track("unbond.started")
     const tx = await aaveStakerSigner.unbond(id, {
-      gasLimit: 1000000,
+      // gas used around 63000
+      gasLimit: 80000,
     })
 
     await doHandleTransaction({

--- a/src/components/_forms/BondForm/index.tsx
+++ b/src/components/_forms/BondForm/index.tsx
@@ -75,18 +75,17 @@ export const BondForm: VFC<BondFormProps> = ({ onClose }) => {
       )
     )
 
-  const onSubmit = async (data: any, e: any) => {
+  const onSubmit = async (data: FormValues) => {
     const analyticsData = {
       duration: bondingPeriodOptions[bondPeriod],
     }
     analytics.track("bond.started", analyticsData)
-
-    await doApprove(data?.depositAmount, {
+    await doApprove(data.depositAmount, {
       onSuccess: () => analytics.track("bond.approval-succeeded"),
       onError: () => analytics.track("bond.approval-failed"),
     })
 
-    const amtInBigNumber = new BigNumber(data?.depositAmount)
+    const amtInBigNumber = new BigNumber(data.depositAmount)
     const depositAmtInWei = ethers.utils.parseUnits(
       amtInBigNumber.toFixed(),
       18
@@ -95,7 +94,8 @@ export const BondForm: VFC<BondFormProps> = ({ onClose }) => {
       const { hash: bondConf } = await sommStakingContract.stake(
         depositAmtInWei,
         bondPeriod,
-        { gasLimit: 1000000 }
+        // gas used around 125000-130000
+        { gasLimit: 200000 }
       )
 
       await doHandleTransaction({


### PR DESCRIPTION
Fixes #360 

## Description

Add more proper `gasLimit` 

## Changes

- [x] [feat(contracts): add more proper gasLimit](https://github.com/strangelove-ventures/sommelier/commit/f84cbb9b8d591b5e7cf2d229b54d1589e30c4619)

## Screenshots:

### Bond LP Token

Gas used estimated 120.000 - 140.000

Before: 
`gasLimit` 1.000.000
<img width="359" alt="CleanShot 2022-08-26 at 03 41 35@2x" src="https://user-images.githubusercontent.com/39829726/186753781-de796542-3344-4b3f-8a2f-37cfeb87cdae.png">

After:
`gasLimit` 200.000
<img width="346" alt="CleanShot 2022-08-26 at 03 40 46@2x" src="https://user-images.githubusercontent.com/39829726/186753653-5653fa03-c9a7-4ac1-9544-1571797f92c1.png">

### Unbond
Gas used estimated around 63.000

Before:
`gasLimit` 1.000.000
<img width="348" alt="CleanShot 2022-08-26 at 03 44 18@2x" src="https://user-images.githubusercontent.com/39829726/186754218-6755ca28-bf36-48ef-a5c2-6784aa027de4.png">

After: 
`gasLimit` 80.000
<img width="352" alt="CleanShot 2022-08-26 at 03 43 33@2x" src="https://user-images.githubusercontent.com/39829726/186754161-230b4eea-3e22-4ff2-9adb-71873134635b.png">
