### PR TITLE
Feat/toast improvements

### DIFF
--- a/src/components/_cards/BridgeCard/InputSommelierAddress.tsx
+++ b/src/components/_cards/BridgeCard/InputSommelierAddress.tsx
@@ -8,7 +8,8 @@ import {
   Icon,
   Image,
 } from "@chakra-ui/react"
-import { InformationIcon } from "components/_icons"
+import { Link } from "components/Link"
+import { ExternalLinkIcon, InformationIcon } from "components/_icons"
 import { getKeplr, mainnetChains } from "graz"
 import { useBrandedToast } from "hooks/chakra"
 import React from "react"
@@ -28,7 +29,6 @@ export const InputSommelierAddress: React.FC<InputProps> = ({
   const onAutofillClick = async () => {
     try {
       const keplr = getKeplr()
-      if (!keplr) throw new Error("Keplr not found")
       const key = await keplr.getKey(mainnetChains.sommelier.chainId)
       if (!key.bech32Address) throw new Error("Address not defined")
       setValue("sommelierAddress", key.bech32Address, {
@@ -36,6 +36,27 @@ export const InputSommelierAddress: React.FC<InputProps> = ({
       })
     } catch (e) {
       const error = e as Error
+      if (error.message === "Keplr is not defined") {
+        return addToast({
+          heading: "Autofill from Keplr",
+          body: (
+            <>
+              <Text>Keplr not found</Text>
+              <Link
+                display="flex"
+                alignItems="center"
+                href="https://www.keplr.app/download"
+                isExternal
+              >
+                <Text as="span">Install Keplr</Text>
+                <ExternalLinkIcon ml={2} />
+              </Link>
+            </>
+          ),
+          status: "error",
+          closeHandler: closeAll,
+        })
+      }
       addToast({
         heading: "Autofill from Keplr",
         body: <Text>{error.message}</Text>,

--- a/src/hooks/web3/useHandleTransaction.tsx
+++ b/src/hooks/web3/useHandleTransaction.tsx
@@ -1,6 +1,8 @@
 import { useWaitForTransaction } from "wagmi"
 import { Text } from "@chakra-ui/react"
 import { useBrandedToast } from "hooks/chakra"
+import { Link } from "components/Link"
+import { ExternalLinkIcon } from "components/_icons"
 
 type TxParams = {
   hash: string
@@ -28,7 +30,6 @@ export const useHandleTransaction = (): {
     onError,
   }: TxParams) => {
     const infoBody = toastBody?.info || <Text>In progress...</Text>
-    const successBody = toastBody?.success || <Text>Successful</Text>
     const errorBody = toastBody?.error || <Text>Failed</Text>
 
     addToast({
@@ -43,6 +44,20 @@ export const useHandleTransaction = (): {
     const result = await waitForApproval
 
     if (result?.data?.transactionHash) {
+      const successBody = toastBody?.success || (
+        <>
+          <Text>Successful</Text>
+          <Link
+            display="flex"
+            alignItems="center"
+            href={`https://etherscan.io/tx/${result?.data?.transactionHash}`}
+            isExternal
+          >
+            <Text as="span">View on Etherscan</Text>
+            <ExternalLinkIcon ml={2} />
+          </Link>
+        </>
+      )
       update({
         heading: "Transaction",
         body: successBody,


### PR DESCRIPTION
Fixes #391 

## Description

Toast improvements

## Changes

- [x] [feat(toast): Install Keplr link](https://github.com/strangelove-ventures/sommelier/commit/3dc178a132154f302b98872b12229d23377320ce)
- [x] [feat(toast): view on etherscan link](https://github.com/strangelove-ventures/sommelier/commit/a015ebb0a42facbf7b5ebd20e3941cb0ac22c16f)

## Screenshots:
![no keplr somm](https://user-images.githubusercontent.com/39829726/187250504-7011e4f6-ba13-42d6-962b-f0dc73a2d7a9.gif)
![CleanShot 2022-08-29 at 23 30 13](https://user-images.githubusercontent.com/39829726/187250524-68a8e7cc-87d3-4d85-9562-3bd7afae0f17.png)

## Testing Steps

1. No Keplr
- Go to /bridge
- connect wallet
- make sure you don't have keplr installed
- click "Autofill from keplr"

2. Bond transcations
- Go to cellar page
- bond token, fill amount
- click "Bond LP token"
- see the toast