### PR TITLE
fix(ui): ether convertion without format

### DIFF
--- a/src/components/_modals/BondModal.tsx
+++ b/src/components/_modals/BondModal.tsx
@@ -17,7 +17,8 @@ export const BondModal: VFC<BondModalProps> = (props) => {
         <VStack align="flex-start">
           <CardHeading>available</CardHeading>
           <Text as="span">
-            {toEther(userData?.balances?.aaveClr)} LP TOKENS
+            {toEther(userData?.balances?.aaveClr, 18, false)} LP
+            TOKENS
           </Text>
         </VStack>
       </VStack>

--- a/src/components/_modals/WithdrawModal.tsx
+++ b/src/components/_modals/WithdrawModal.tsx
@@ -23,7 +23,8 @@ export const WithdrawModal: VFC<WithdrawModalProps> = ({
         <VStack align="flex-start">
           <CardHeading>available</CardHeading>
           <Text as="span">
-            {toEther(userData?.balances?.aaveClr, 18)} LP TOKENS
+            {toEther(userData?.balances?.aaveClr, 18, false)} LP
+            TOKENS
           </Text>
         </VStack>
       </VStack>


### PR DESCRIPTION
Fixes #447 

## Description

`toEther` need to set format false to show the correct amount

## Changes

- [x] [fix(ui): ether convertion without format](https://github.com/strangelove-ventures/sommelier/commit/021ab0388119c8849323329e5ede097da10f2a2e)

## Screenshots:
![CleanShot 2022-08-31 at 23 50 10](https://user-images.githubusercontent.com/39829726/187734785-31e58cda-5c62-491b-851a-8c2345c21395.png)
![CleanShot 2022-08-31 at 23 50 20](https://user-images.githubusercontent.com/39829726/187734794-2d4ba728-e4c6-47b9-8c51-2128789050a9.png)
