### PR TITLE
refactor: separate tokenConfig and depositAssetTokenConfig

### DIFF
--- a/src/components/_cards/PortfolioCard.tsx
+++ b/src/components/_cards/PortfolioCard.tsx
@@ -10,7 +10,7 @@ import { BaseButton } from "components/_buttons/BaseButton"
 import { useHandleTransaction } from "hooks/web3"
 import BondingTableCard from "./BondingTableCard"
 import { useAccount, useConnect } from "wagmi"
-import { tokenConfig } from "data/tokenConfig"
+import { depositAssetTokenConfig } from "data/tokenConfig"
 import { TokenAssets } from "components/TokenAssets"
 import { DepositButton } from "components/_buttons/DepositButton"
 import { WithdrawButton } from "components/_buttons/WithdrawButton"
@@ -99,7 +99,7 @@ export const PortfolioCard: VFC<BoxProps> = (props) => {
               spacing={0}
             >
               <TokenAssets
-                tokens={tokenConfig}
+                tokens={depositAssetTokenConfig}
                 activeAsset={activeAsset?.address || ""}
                 displaySymbol
               />

--- a/src/components/_menus/ModalMenu/Menu.tsx
+++ b/src/components/_menus/ModalMenu/Menu.tsx
@@ -17,7 +17,7 @@ import {
 } from "@chakra-ui/react"
 import { useRef, VFC } from "react"
 import { FaChevronDown } from "react-icons/fa"
-import { Token, tokenConfig } from "data/tokenConfig"
+import { depositAssetTokenConfig, Token } from "data/tokenConfig"
 import { useFormContext } from "react-hook-form"
 import { toEther } from "utils/formatCurrency"
 import { ModalMenuProps } from "."
@@ -116,13 +116,15 @@ export const Menu: VFC<MenuProps> = ({
           w={menuDims?.borderBox.width}
         >
           <MenuOptionGroup
-            defaultValue={activeAsset && tokenConfig[0].symbol}
+            defaultValue={
+              activeAsset && depositAssetTokenConfig[0].symbol
+            }
             type="radio"
           >
             <Box pt={4} pb={2} pl={10}>
               <Text color="neutral.400">Select deposit asset</Text>
             </Box>
-            {tokenConfig.map((token) => {
+            {depositAssetTokenConfig.map((token) => {
               const { address, src, alt, symbol } = token
               const isActiveAsset =
                 token.address.toUpperCase() ===

--- a/src/components/_modals/DepositModal.tsx
+++ b/src/components/_modals/DepositModal.tsx
@@ -17,7 +17,11 @@ import { BaseButton } from "components/_buttons/BaseButton"
 import { AiOutlineInfo } from "react-icons/ai"
 import { FiSettings } from "react-icons/fi"
 import { ModalMenu } from "components/_menus/ModalMenu"
-import { Token as TokenType, tokenConfig } from "data/tokenConfig"
+import {
+  depositAssetTokenConfig,
+  Token as TokenType,
+  tokenConfig,
+} from "data/tokenConfig"
 import { Link } from "components/Link"
 import { config } from "utils/config"
 import {
@@ -443,14 +447,14 @@ export const DepositModal: VFC<DepositModalProps> = (props) => {
   useEffect(() => {
     if (currentAsset === undefined) return
 
-    const indexOfActiveAsset = tokenConfig.findIndex(
+    const indexOfActiveAsset = depositAssetTokenConfig.findIndex(
       (token) => token === currentAsset
     )
 
-    tokenConfig.splice(
+    depositAssetTokenConfig.splice(
       0,
       0,
-      tokenConfig.splice(indexOfActiveAsset, 1)[0]
+      depositAssetTokenConfig.splice(indexOfActiveAsset, 1)[0]
     )
   }, [activeAsset?.address, currentAsset])
 

--- a/src/data/tokenConfig.ts
+++ b/src/data/tokenConfig.ts
@@ -5,6 +5,10 @@ export interface Token {
   address: string
 }
 
+/**
+ *
+ *  tokenConfig is for storing the all token data that used in the app
+ */
 export const tokenConfig: Token[] = [
   {
     src: "/assets/icons/ampl.png",
@@ -79,3 +83,22 @@ export const tokenConfig: Token[] = [
     address: "0xdac17f958d2ee523a2206206994597c13d831ec7",
   },
 ]
+
+const depositAssetTokenList = [
+  "AMPL",
+  "BUSD",
+  "DAI",
+  "FEI",
+  "FRAX",
+  "GUSD",
+  "USDP",
+  "RAI",
+  "sUSD",
+  "TUSD",
+  "USDC",
+  "USDT",
+]
+
+export const depositAssetTokenConfig: Token[] = tokenConfig.filter(
+  (token) => depositAssetTokenList.includes(token.symbol)
+)


### PR DESCRIPTION
## Description

Separating `tokenConfig` and `depositAssetTokenConfig` because it is used to contain token config, so if we want to add more token config we can add it there

## Changes

- [x] [refactor: separate tokenConfig and depositAssetTokenConfig](https://github.com/strangelove-ventures/sommelier/commit/63cf1ac44aecf993c8b1bffab84065b77e3b12ad)
