### PR TITLE
fix: sell button disabled if the value below 1

### DIFF
--- a/src/components/_cards/PortfolioCard/index.tsx
+++ b/src/components/_cards/PortfolioCard/index.tsx
@@ -38,7 +38,9 @@ export const PortfolioCard: VFC<BoxProps> = (props) => {
   const { data: lpTokenData } = lpToken
 
   const lpTokenDisabled =
-    !lpTokenData || parseInt(toEther(lpTokenData?.formatted, 18)) <= 0
+    !lpTokenData ||
+    Number(toEther(lpTokenData?.formatted, lpTokenData?.decimals)) <=
+      0
 
   const { data: userStakes } = useUserStakes(cellarConfig)
 


### PR DESCRIPTION
## Description

Fixes Sell button disabled if the value below 1. appearently `parseInt` causes this bug happen

## Changes

- [x] [fix: sell button disabled if the value below 1](https://github.com/strangelove-ventures/sommelier/commit/56777dd534a8dd284e04b33a997d4a4cdf67e821)

## Testing Steps

- go to one of the cellar manage page
- deposit/buy below 1 lp token (0. ) 
- check sell button is disabled or not
