### PR TITLE
Feat/554 update links to access strategy pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,6 +15,30 @@ const SentryOptions = {
 let nextConfig = {
   reactStrictMode: true,
   outputFileTracing: false, // Temporary fix for Sentry + Next 12 bug
+  redirects: async () => {
+    return [
+      {
+        source:
+          "/strategies/0x6e2dac3b9e9adc0cbbae2d0b9fd81952a8d33872",
+        destination: `/strategies/ETH-BTC-Momentum`,
+        permanent: true,
+        basePath: false,
+      },
+      {
+        source: `/strategies/0x6b7f87279982d919bbf85182ddeab179b366d8f2`,
+        destination: `/strategies/ETH-BTC-Trend`,
+        permanent: true,
+        basePath: false,
+      },
+      {
+        source:
+          "/strategies/0x7bad5df5e11151dc5ee1a648800057c5c934c0d5",
+        destination: "/strategies/AAVE",
+        permanent: true,
+        basePath: false,
+      },
+    ]
+  },
 }
 
 // https://github.com/vercel/next.js/tree/canary/packages/next-bundle-analyzer

--- a/src/components/_pages/PageHome.tsx
+++ b/src/components/_pages/PageHome.tsx
@@ -69,7 +69,7 @@ const PageHome: NextPage<HomeProps> = ({ faqData }) => {
             align={{ base: "center", md: "initial" }}
           >
             <Box mb={12}>
-              <Heading>Cellars</Heading>
+              <Heading>Strategies</Heading>
             </Box>
             <GridHome>
               <CellarGridItems />

--- a/src/data/cellarDataMap.ts
+++ b/src/data/cellarDataMap.ts
@@ -8,7 +8,7 @@ import {
 } from "./types"
 
 export const cellarDataMap: CellarDataMap = {
-  [config.CONTRACT.AAVE_V2_STABLE_CELLAR.ADDRESS]: {
+  [config.CONTRACT.AAVE_V2_STABLE_CELLAR.SLUG]: {
     name: "aave2",
     description:
       "The Aave stablecoin strategy aims to select the optimal stablecoin lending position available to lend across Aave markets on a continuous basis.",
@@ -69,7 +69,7 @@ export const cellarDataMap: CellarDataMap = {
       rewardTokenAddress: config.CONTRACT.SOMMELLIER.ADDRESS,
     },
   },
-  [config.CONTRACT.ETH_BTC_TREND_CELLAR.ADDRESS]: {
+  [config.CONTRACT.ETH_BTC_TREND_CELLAR.SLUG]: {
     name: "ETH-BTC Trend",
     description:
       "A long-only strategy for dynamic BTC-ETH portfolio management. A better way to hold while better managing the negative volatility.",
@@ -202,13 +202,13 @@ export const cellarDataMap: CellarDataMap = {
         <li>Best month: shows the return of the portfolio during the best month in the observation period.</li>
         <li>Worst month: shows the return of the portfolio during the worst month in the observation period and can be considered one indicator of downside risk.</li>
       </ul>
-      <br/> 
-      
+      <br/>
+
       Please remember that past performance is not indicative of future results. The backtesting procedure for the Cleargate strategies has followed all the best practices of backtesting to reduce the risks of over-optimising the strategies and takes account of actual trade execution costs and slippage.`,
       },
     ],
   },
-  [config.CONTRACT.ETH_BTC_MOMENTUM_CELLAR.ADDRESS]: {
+  [config.CONTRACT.ETH_BTC_MOMENTUM_CELLAR.SLUG]: {
     name: "ETH-BTC Momentum",
     description:
       "A dynamic long-only strategy for BTC-ETH portfolio management. More responsive to recent market changes and slightly more risky than BTC-ETH Trend strategy.",
@@ -343,7 +343,7 @@ export const cellarDataMap: CellarDataMap = {
         <li>Worst month: shows the return of the portfolio during the worst month in the observation period and can be considered one indicator of downside risk.</li>
       </ul>
      <br/>
-      
+
       Please remember that past performance is not indicative of future results. The backtesting procedure for the Cleargate strategies has followed all the best practices of backtesting to reduce the risks of over-optimising the strategies and takes account of actual trade execution costs and slippage.
       `,
       },

--- a/src/data/strategyPageContentData.tsx
+++ b/src/data/strategyPageContentData.tsx
@@ -3,7 +3,7 @@ import { Image, Text } from "@chakra-ui/react"
 import { config } from "utils/config"
 
 export const strategyPageContentData = {
-  [config.CONTRACT.ETH_BTC_TREND_CELLAR.ADDRESS]: {
+  [config.CONTRACT.ETH_BTC_TREND_CELLAR.SLUG]: {
     name: "ETH-BTC Trend Strategy",
     provider: "Cleargate Capital",
     providerUrl: "https://cleargate.capital/",
@@ -76,7 +76,7 @@ export const strategyPageContentData = {
 
       Presented results are based on historical backtests. Past performance is not indicative of future results. Actual performance will depend on market conditions.`,
   },
-  [config.CONTRACT.ETH_BTC_MOMENTUM_CELLAR.ADDRESS]: {
+  [config.CONTRACT.ETH_BTC_MOMENTUM_CELLAR.SLUG]: {
     name: "ETH-BTC Momentum Strategy",
     provider: "Cleargate Capital",
     providerUrl: "https://cleargate.capital/",

--- a/src/data/strategyPageContentData.tsx
+++ b/src/data/strategyPageContentData.tsx
@@ -43,7 +43,7 @@ export const strategyPageContentData = {
     strategyHighlights: {
       card: [
         "Holds a combination of BTC and ETH with smart rebalancing depending on market conditions.",
-        "High exposure to BTC and ETH when price trend goes up, no exposure when the trend is down.",
+        "Has high exposure to BTC and ETH when the price trend goes up, no exposure when the trend is down.",
         "Risk management rules to reduce risks in unfavorable market.",
       ],
       description:
@@ -117,7 +117,7 @@ export const strategyPageContentData = {
       card: [
         "Holds a combination of BTC and ETH with smart rebalancing to suit market conditions.",
         "Has high exposure to BTC and ETH when the price trend goes up, no exposure when the trend is down.",
-        "Uses risk management rules to reduce risks in unfavorable market conditions and exit completely in a bear market.",
+        "Uses risk management rules to reduce risks in unfavorable market conditions.",
       ],
     },
     howItWorks: `ETH-BTC Trend strategy aims to provide a better risk-return tradeoff than holding ETH and/or BTC. The cellar accumulates BTC and ETH relative to USDC with a medium to long-term perspective. The

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -22,6 +22,7 @@ export const config = {
       // ADDRESS: "0xd15135141f1217b8863cb1431ad71309ef22ceda",
       ADDRESS: "0x7bad5df5e11151dc5ee1a648800057c5c934c0d5",
       ABI: aaveV2CellarAbi,
+      SLUG: "AAVE",
     },
     CELLAR_ROUTER: {
       // ADDRESS: "0xe30574344eB64c7c9012DE52D95b0b4f89f2C6d1",
@@ -69,10 +70,12 @@ export const config = {
     ETH_BTC_TREND_CELLAR: {
       ADDRESS: "0x6b7f87279982d919bbf85182ddeab179b366d8f2",
       ABI: clearGateCellar,
+      SLUG: "ETH-BTC-Trend",
     },
     ETH_BTC_MOMENTUM_CELLAR: {
       ADDRESS: "0x6e2dac3b9e9adc0cbbae2d0b9fd81952a8d33872",
       ABI: clearGateCellar,
+      SLUG: "ETH-BTC-Momentum",
     },
     CLEAR_GATE_TEST_CELLAR_A: {
       ADDRESS: "0xbfc413ea6cb68c05deda0d9aa7daf8e51a7dddff",


### PR DESCRIPTION
Related #554 #556 

## Description

I add new property called slug in config.ts so we can have custom url instead of using address, currently just implement this on available cellars for launch.
I also update the naming from Cellars to Strategies in home page

## Changes

List any technical changes.

- [x] add new property called lug in config.ts
- [x] update cellarDataMap and strategyContentData
- [x] update the naming from Cellars to Strategies in home page

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/43783037/198141535-e9c33a73-0a22-48a1-b763-05107dadbba7.png)
