### PR TITLE
Make deposit token list configurable per cellar

### DIFF
--- a/src/components/_menus/ModalMenu/Menu.tsx
+++ b/src/components/_menus/ModalMenu/Menu.tsx
@@ -17,7 +17,7 @@ import {
 } from "@chakra-ui/react"
 import { useRef, VFC } from "react"
 import { FaChevronDown } from "react-icons/fa"
-import { depositAssetTokenConfig, Token } from "data/tokenConfig"
+import { getTokenConfig, Token } from "data/tokenConfig"
 import { useFormContext } from "react-hook-form"
 import { toEther } from "utils/formatCurrency"
 import { ModalMenuProps } from "."
@@ -30,6 +30,7 @@ export interface MenuProps
 }
 
 export const Menu: VFC<MenuProps> = ({
+  depositTokens,
   activeAsset,
   selectedTokenBalance,
   value,
@@ -43,6 +44,8 @@ export const Menu: VFC<MenuProps> = ({
     selectedTokenBalance?.value,
     selectedTokenBalance?.decimals
   )}`
+
+  const depositTokenConfig = getTokenConfig(depositTokens)
   const setMax = () => {
     analytics.track("deposit.max-selected", {
       value: selectedTokenBalance?.value?.toString(),
@@ -110,15 +113,13 @@ export const Menu: VFC<MenuProps> = ({
           w={menuDims?.borderBox.width}
         >
           <MenuOptionGroup
-            defaultValue={
-              activeAsset && depositAssetTokenConfig[0].symbol
-            }
+            defaultValue={activeAsset && depositTokenConfig[0].symbol}
             type="radio"
           >
             <Box pt={4} pb={2} pl={10}>
               <Text color="neutral.400">Select deposit asset</Text>
             </Box>
-            {depositAssetTokenConfig.map((token) => {
+            {depositTokenConfig.map((token) => {
               const { address, src, alt, symbol } = token
               const isActiveAsset =
                 token.address.toUpperCase() ===

--- a/src/components/_menus/ModalMenu/index.tsx
+++ b/src/components/_menus/ModalMenu/index.tsx
@@ -4,6 +4,7 @@ import { Menu } from "./Menu"
 import { BigNumber } from "ethers"
 
 export interface ModalMenuProps {
+  depositTokens: string[]
   setSelectedToken: (value: any) => void
   activeAsset?: string
   selectedTokenBalance?: {
@@ -15,6 +16,7 @@ export interface ModalMenuProps {
 }
 
 export const ModalMenu: VFC<ModalMenuProps> = ({
+  depositTokens,
   activeAsset,
   selectedTokenBalance,
   setSelectedToken,
@@ -28,6 +30,7 @@ export const ModalMenu: VFC<ModalMenuProps> = ({
       render={({ field: { value, onChange } }) => {
         return (
           <Menu
+            depositTokens={depositTokens}
             value={value}
             activeAsset={activeAsset}
             selectedTokenBalance={selectedTokenBalance}

--- a/src/components/_modals/DepositModal.tsx
+++ b/src/components/_modals/DepositModal.tsx
@@ -59,6 +59,7 @@ export const DepositModal: VFC<DepositModalProps> = (props) => {
   const id = useRouter().query.id as string
   const cellarConfig = cellarDataMap[id].config
   const cellarName = cellarDataMap[id].name
+  const depositTokens = cellarDataMap[id].depositTokens.list
 
   const { data: signer } = useSigner()
   const { address } = useAccount()
@@ -416,6 +417,7 @@ export const DepositModal: VFC<DepositModalProps> = (props) => {
             </Flex>
 
             <ModalMenu
+              depositTokens={depositTokens}
               setSelectedToken={trackedSetSelectedToken}
               activeAsset={activeAsset?.address}
               selectedTokenBalance={selectedTokenBalance}

--- a/src/data/strategies/aave-stable.ts
+++ b/src/data/strategies/aave-stable.ts
@@ -1,5 +1,6 @@
 import { config } from "utils/config"
 import { CellarKey, CellarRouterKey, StakerKey } from "../types"
+import { depositAssetTokenList } from "../tokenConfig"
 
 export const aaveStable = {
   name: "aave2",
@@ -38,6 +39,9 @@ export const aaveStable = {
     href: "https://7seas.capital/",
     tooltip:
       "A Strategy Provider is responsible for providing the instructions for a cellar to execute",
+  },
+  depositTokens: {
+    list: depositAssetTokenList,
   },
   config: {
     id: config.CONTRACT.AAVE_V2_STABLE_CELLAR.ADDRESS,

--- a/src/data/strategies/eth-btc-momentum.ts
+++ b/src/data/strategies/eth-btc-momentum.ts
@@ -1,5 +1,6 @@
 import { config } from "utils/config"
 import { CellarKey, CellarRouterKey } from "../types"
+import { depositTokenListWithEthBtc } from "../tokenConfig"
 
 export const ethBtcMomentum = {
   name: "ETH-BTC Momentum",
@@ -68,6 +69,9 @@ export const ethBtcMomentum = {
     tooltip:
       "Backtested APY results are based on historical backtests. Past performance is not indicative of future results. Actual performance will depend on market conditions",
     value: "84.15%",
+  },
+  depositTokens: {
+    list: depositTokenListWithEthBtc,
   },
   config: {
     id: config.CONTRACT.ETH_BTC_MOMENTUM_CELLAR.ADDRESS,

--- a/src/data/strategies/eth-btc-trend.ts
+++ b/src/data/strategies/eth-btc-trend.ts
@@ -1,5 +1,6 @@
 import { config } from "utils/config"
 import { CellarKey, CellarRouterKey } from "../types"
+import { depositTokenListWithEthBtc } from "../tokenConfig"
 
 export const ethBtcTrend = {
   name: "ETH-BTC Trend",
@@ -67,6 +68,9 @@ export const ethBtcTrend = {
     tooltip:
       "Backtested APY results are based on historical backtests. Past performance is not indicative of future results. Actual performance will depend on market conditions",
     value: "123.72%",
+  },
+  depositTokens: {
+    list: depositTokenListWithEthBtc,
   },
   config: {
     id: config.CONTRACT.ETH_BTC_TREND_CELLAR.ADDRESS,

--- a/src/data/tokenConfig.ts
+++ b/src/data/tokenConfig.ts
@@ -96,7 +96,7 @@ export const tokenConfig: Token[] = [
   },
 ]
 
-const depositAssetTokenList = [
+export const depositAssetTokenList = [
   "AMPL",
   "BUSD",
   "DAI",
@@ -111,6 +111,18 @@ const depositAssetTokenList = [
   "USDT",
 ]
 
+export const depositTokenListWithEthBtc = [
+  ...depositAssetTokenList,
+  "ETH",
+  "BTC",
+]
+
 export const depositAssetTokenConfig: Token[] = tokenConfig.filter(
   (token) => depositAssetTokenList.includes(token.symbol)
 )
+
+export function getTokenConfig(tokenList: string[]) {
+  return tokenConfig.filter((token) =>
+    tokenList.includes(token.symbol)
+  )
+}

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -60,6 +60,9 @@ export interface CellarDataMap {
       value: string
       tooltip: string
     }
+    depositTokens: {
+      list: string[]
+    }
     config: ConfigProps
     faq?: {
       question: string


### PR DESCRIPTION
## Issue
https://github.com/orgs/strangelove-ventures/projects/11

## Description
Adds ETH and BTC as deposit assets for the cleargate cellars

## Changes
- Makes deposit token list configurable per cellar
- Adds ETH and BTC to cleargate cellars only
- Aave cellar is configured with existing list (no ETH or BTC)

Cleargate list
![image](https://user-images.githubusercontent.com/1229188/198220344-815df9f7-99bb-4f09-a79c-94d06c36a55c.png)
![image](https://user-images.githubusercontent.com/1229188/198220400-2991f42d-4550-441b-b113-260ac7584c3a.png)

Aave list
![image](https://user-images.githubusercontent.com/1229188/198220273-7fa35a96-43db-4b6c-a90a-e5732cf1e09f.png)