### PR TITLE
fix: add more decimals to show on available balance

### DIFF
--- a/src/components/_menus/ModalMenu/Menu.tsx
+++ b/src/components/_menus/ModalMenu/Menu.tsx
@@ -42,7 +42,9 @@ export const Menu: VFC<MenuProps> = ({
   const { register, setValue, clearErrors } = useFormContext()
   const availableBalance = `${toEther(
     selectedTokenBalance?.value,
-    selectedTokenBalance?.decimals
+    selectedTokenBalance?.decimals,
+    false,
+    6
   )}`
 
   const depositTokenConfig = getTokenConfig(depositTokens)
@@ -180,14 +182,8 @@ export const Menu: VFC<MenuProps> = ({
                 v > 0 || "You must submit a positive amount.",
               lessThanBalance: (v) => {
                 return (
-                  v <=
-                    parseFloat(
-                      toEther(
-                        selectedTokenBalance?.value || "",
-                        selectedTokenBalance?.decimals,
-                        false
-                      )
-                    ) || "Insufficient balance"
+                  v <= parseFloat(availableBalance) ||
+                  "Insufficient balance"
                 )
               },
               // depositLessThanFifty: (v) =>


### PR DESCRIPTION
## Description

If decimals is too many the available balance is always 0. So I added 6 decimals to show available balance

## Changes

- [x] [fix: add more decimals to show on available balance](https://github.com/strangelove-ventures/sommelier/commit/bab2e0a0a4c74fbc83a15625da894b02d42934c5)

## Screenshots :

<img width="417" alt="CleanShot 2022-10-27 at 16 24 40@2x" src="https://user-images.githubusercontent.com/39829726/198246791-577c7283-4b8d-4a3a-898d-8c90b37b444f.png">


