### PR TITLE
feat: update tooltip to use depositTokens list

### DIFF
--- a/src/components/_cards/PortfolioCard/index.tsx
+++ b/src/components/_cards/PortfolioCard/index.tsx
@@ -7,7 +7,7 @@ import { TransparentCard } from "../TransparentCard"
 import { toEther } from "utils/formatCurrency"
 import BondingTableCard from "../BondingTableCard"
 import { useAccount, useConnect } from "wagmi"
-import { depositAssetTokenConfig } from "data/tokenConfig"
+import { getTokenConfig } from "data/tokenConfig"
 import { TokenAssets } from "components/TokenAssets"
 import { DepositButton } from "components/_buttons/DepositButton"
 import { WithdrawButton } from "components/_buttons/WithdrawButton"
@@ -31,6 +31,8 @@ export const PortfolioCard: VFC<BoxProps> = (props) => {
   const { isConnected } = useAccount()
   const id = useRouter().query.id as string
   const cellarConfig = cellarDataMap[id].config
+  const depositTokens = cellarDataMap[id].depositTokens.list
+  const depositTokenConfig = getTokenConfig(depositTokens)
 
   const { connectors } = useConnect()
 
@@ -82,7 +84,7 @@ export const PortfolioCard: VFC<BoxProps> = (props) => {
               spacing={0}
             >
               <TokenAssets
-                tokens={depositAssetTokenConfig}
+                tokens={depositTokenConfig}
                 activeAsset={activeAsset?.address || ""}
                 displaySymbol
               />


### PR DESCRIPTION
Update for #555 

## Description

Update tooltip to use cellarDataMap depositToken list 

## Changes

List any technical changes.

- [x] Update portfolio card tooltip to use cellarDataMap depositToken list instead of depositAssetTokenConfig

## Screenshots (if appropriate):

aave
<img width="204" alt="image" src="https://user-images.githubusercontent.com/43783037/198252968-7dcb595b-970c-4d81-84fb-a70fb9ed8b42.png">

ETH-BTC Trend & ETH-BTC Momentum
<img width="181" alt="image" src="https://user-images.githubusercontent.com/43783037/198253151-27845b6c-93cb-486f-8cb3-ed85165284c7.png">
