### PR TITLE
Feat/588 token price second design iteration

### DIFF
--- a/src/components/CellarStatsAutomated.tsx
+++ b/src/components/CellarStatsAutomated.tsx
@@ -111,7 +111,7 @@ export const CellarStatsAutomated: VFC<CellarStatsAutomatedProps> = ({
         {monthChangeValue}
         <Box
           onMouseEnter={debounce(() => {
-            analytics.track("user.tooltip-opened-daily-change")
+            analytics.track("user.tooltip-opened-monthly-change")
           }, 1000)}
         >
           <Tooltip

--- a/src/components/CellarStatsAutomated.tsx
+++ b/src/components/CellarStatsAutomated.tsx
@@ -24,9 +24,9 @@ interface CellarStatsAutomatedProps extends StackProps {
   weekChangeTooltip?: string
   weekChangeLabel?: string
   weekChangeValue?: ReactNode
-  changeVsEthBtcTooltip?: string
-  changeVsEthBtcLabel?: string
-  changeVsEthBtcValue?: ReactNode
+  monthChangeTooltip?: string
+  monthChangeLabel?: string
+  monthChangeValue?: ReactNode
   cellarConfig: ConfigProps
   currentDeposits?: string
   cellarCap?: string
@@ -40,9 +40,9 @@ export const CellarStatsAutomated: VFC<CellarStatsAutomatedProps> = ({
   weekChangeTooltip,
   weekChangeLabel,
   weekChangeValue,
-  changeVsEthBtcTooltip,
-  changeVsEthBtcLabel,
-  changeVsEthBtcValue,
+  monthChangeTooltip,
+  monthChangeLabel,
+  monthChangeValue,
   cellarConfig,
   currentDeposits,
   cellarCap,
@@ -57,9 +57,9 @@ export const CellarStatsAutomated: VFC<CellarStatsAutomatedProps> = ({
   return (
     <HStack
       spacing={8}
-      align="start"
       wrap="wrap"
       rowGap={4}
+      align="start"
       divider={
         <CardDivider
           css={{
@@ -71,7 +71,7 @@ export const CellarStatsAutomated: VFC<CellarStatsAutomatedProps> = ({
       }
       {...rest}
     >
-      <VStack spacing={1} align="flex-start">
+      <VStack spacing={1} align="center">
         <Heading size="md">{tokenPriceValue}</Heading>
         <Tooltip
           hasArrow
@@ -86,30 +86,7 @@ export const CellarStatsAutomated: VFC<CellarStatsAutomatedProps> = ({
           </HStack>
         </Tooltip>
       </VStack>
-      <VStack spacing={1} w={28} textAlign="center">
-        {changeVsEthBtcValue}
-        <Box
-          onMouseEnter={debounce(() => {
-            analytics.track(
-              "user.tooltip-opened-1m-change-vs-eth-btc-50-50"
-            )
-          }, 1000)}
-        >
-          <Tooltip
-            hasArrow
-            placement="top"
-            label={changeVsEthBtcTooltip}
-            bg="surface.bg"
-            color="neutral.300"
-          >
-            <HStack spacing={1} align="center">
-              <CardHeading>{changeVsEthBtcLabel}</CardHeading>
-              <InformationIcon color="neutral.300" boxSize={3} />
-            </HStack>
-          </Tooltip>
-        </Box>
-      </VStack>
-      {/* <VStack spacing={1} align="flex-start">
+      <VStack spacing={1} align="center">
         {weekChangeValue}
         <Box
           onMouseEnter={debounce(() => {
@@ -130,7 +107,29 @@ export const CellarStatsAutomated: VFC<CellarStatsAutomatedProps> = ({
           </Tooltip>
         </Box>
       </VStack>
-        */}
+      <VStack spacing={1} align="center" w="7rem">
+        {monthChangeValue}
+        <Box
+          onMouseEnter={debounce(() => {
+            analytics.track("user.tooltip-opened-daily-change")
+          }, 1000)}
+        >
+          <Tooltip
+            hasArrow
+            placement="top"
+            label={monthChangeTooltip}
+            bg="surface.bg"
+            color="neutral.300"
+          >
+            <HStack spacing={1} align="center">
+              <CardHeading textAlign="center">
+                {monthChangeLabel}
+              </CardHeading>
+              <InformationIcon color="neutral.300" boxSize={3} />
+            </HStack>
+          </Tooltip>
+        </Box>
+      </VStack>
       {isCurrentDepositsEnabled(cellarConfig) && (
         <CurrentDeposits
           currentDeposits={currentDeposits}

--- a/src/components/CellarStatsAutomated.tsx
+++ b/src/components/CellarStatsAutomated.tsx
@@ -24,6 +24,9 @@ interface CellarStatsAutomatedProps extends StackProps {
   weekChangeTooltip?: string
   weekChangeLabel?: string
   weekChangeValue?: ReactNode
+  changeVsEthBtcTooltip?: string
+  changeVsEthBtcLabel?: string
+  changeVsEthBtcValue?: ReactNode
   cellarConfig: ConfigProps
   currentDeposits?: string
   cellarCap?: string
@@ -37,6 +40,9 @@ export const CellarStatsAutomated: VFC<CellarStatsAutomatedProps> = ({
   weekChangeTooltip,
   weekChangeLabel,
   weekChangeValue,
+  changeVsEthBtcTooltip,
+  changeVsEthBtcLabel,
+  changeVsEthBtcValue,
   cellarConfig,
   currentDeposits,
   cellarCap,
@@ -51,6 +57,7 @@ export const CellarStatsAutomated: VFC<CellarStatsAutomatedProps> = ({
   return (
     <HStack
       spacing={8}
+      align="start"
       wrap="wrap"
       rowGap={4}
       divider={
@@ -79,7 +86,30 @@ export const CellarStatsAutomated: VFC<CellarStatsAutomatedProps> = ({
           </HStack>
         </Tooltip>
       </VStack>
-      <VStack spacing={1} align="flex-start">
+      <VStack spacing={1} w={28} textAlign="center">
+        {changeVsEthBtcValue}
+        <Box
+          onMouseEnter={debounce(() => {
+            analytics.track(
+              "user.tooltip-opened-1m-change-vs-eth-btc-50-50"
+            )
+          }, 1000)}
+        >
+          <Tooltip
+            hasArrow
+            placement="top"
+            label={changeVsEthBtcTooltip}
+            bg="surface.bg"
+            color="neutral.300"
+          >
+            <HStack spacing={1} align="center">
+              <CardHeading>{changeVsEthBtcLabel}</CardHeading>
+              <InformationIcon color="neutral.300" boxSize={3} />
+            </HStack>
+          </Tooltip>
+        </Box>
+      </VStack>
+      {/* <VStack spacing={1} align="flex-start">
         {weekChangeValue}
         <Box
           onMouseEnter={debounce(() => {
@@ -100,6 +130,7 @@ export const CellarStatsAutomated: VFC<CellarStatsAutomatedProps> = ({
           </Tooltip>
         </Box>
       </VStack>
+        */}
       {isCurrentDepositsEnabled(cellarConfig) && (
         <CurrentDeposits
           currentDeposits={currentDeposits}

--- a/src/components/HeroStrategy/hero-right.tsx
+++ b/src/components/HeroStrategy/hero-right.tsx
@@ -61,7 +61,7 @@ export const HeroStrategyRight: VFC<HeroStrategyRightProps> = ({
         justifyContent="space-around"
         divider={<StackDivider borderColor="purple.dark" />}
       >
-        <VStack>
+        <VStack w="50%">
           <Heading size="md">{tokenPrice || <Spinner />}</Heading>
           <CellarStatsLabel
             tooltip="The dollar value of the ETH, BTC, and USDC that 1 token can be redeemed for"

--- a/src/components/HeroStrategy/hero-right.tsx
+++ b/src/components/HeroStrategy/hero-right.tsx
@@ -82,7 +82,7 @@ export const HeroStrategyRight: VFC<HeroStrategyRightProps> = ({
         alignItems="start"
         divider={<StackDivider borderColor="purple.dark" />}
       >
-        <VStack w="30%">
+        <VStack flex={1}>
           <Heading size="md">{tokenPrice || <Spinner />}</Heading>
           <CellarStatsLabel
             tooltip="The dollar value of the ETH, BTC, and USDC that 1 token can be redeemed for"
@@ -90,7 +90,7 @@ export const HeroStrategyRight: VFC<HeroStrategyRightProps> = ({
           />
         </VStack>
 
-        <VStack w="30%">
+        <VStack flex={1}>
           {dailyChange && (
             <PercentageText data={dailyChange} headingSize="md" />
           )}
@@ -100,7 +100,7 @@ export const HeroStrategyRight: VFC<HeroStrategyRightProps> = ({
           />
         </VStack>
 
-        <VStack w="30%" textAlign="center">
+        <VStack flex={1} textAlign="center">
           {intervalGainPct.data && (
             <PercentageText
               data={intervalGainPct.data}

--- a/src/components/HeroStrategy/hero-right.tsx
+++ b/src/components/HeroStrategy/hero-right.tsx
@@ -21,6 +21,7 @@ import { VFC } from "react"
 import { PercentageText } from "components/PercentageText"
 import { CellarStatsLabel } from "components/_cards/CellarCard/CellarStats"
 import { useTvm } from "data/hooks/useTvm"
+import { useIntervalGainPct } from "data/hooks/useIntervalGainPct"
 
 interface HeroStrategyRightProps {
   id: string
@@ -35,6 +36,7 @@ export const HeroStrategyRight: VFC<HeroStrategyRightProps> = ({
   const cellarConfig = cellarData.config
   const { data: tokenPrice } = useTokenPrice(cellarConfig)
   const { data: dailyChange } = useDailyChange(cellarConfig)
+  const intervalGainPct = useIntervalGainPct(cellarConfig)
   const tvm = useTvm(cellarConfig)
 
   return (
@@ -59,9 +61,10 @@ export const HeroStrategyRight: VFC<HeroStrategyRightProps> = ({
       <HStack
         pt={4}
         justifyContent="space-around"
+        alignItems="start"
         divider={<StackDivider borderColor="purple.dark" />}
       >
-        <VStack w="50%">
+        <VStack w="30%">
           <Heading size="md">{tokenPrice || <Spinner />}</Heading>
           <CellarStatsLabel
             tooltip="The dollar value of the ETH, BTC, and USDC that 1 token can be redeemed for"
@@ -69,13 +72,26 @@ export const HeroStrategyRight: VFC<HeroStrategyRightProps> = ({
           />
         </VStack>
 
-        <VStack>
+        <VStack w="30%">
           {dailyChange && (
             <PercentageText data={dailyChange} headingSize="md" />
           )}
           <CellarStatsLabel
             tooltip="% change of current token price vs. token price yesterday"
             title="1D Change"
+          />
+        </VStack>
+
+        <VStack w="30%" textAlign="center">
+          {intervalGainPct.data && (
+            <PercentageText
+              data={intervalGainPct.data}
+              headingSize="md"
+            />
+          )}
+          <CellarStatsLabel
+            title="1M Change vs ETH/BTC 50/50"
+            tooltip="% change of token price compared to a benchmark portfolio of 50% ETH and 50% BTC"
           />
         </VStack>
       </HStack>

--- a/src/components/HeroStrategy/hero-right.tsx
+++ b/src/components/HeroStrategy/hero-right.tsx
@@ -108,7 +108,7 @@ export const HeroStrategyRight: VFC<HeroStrategyRightProps> = ({
             />
           )}
           <CellarStatsLabel
-            title="1M Change vs ETH/BTC 50/50"
+            title="1W Change vs ETH/BTC 50/50"
             tooltip="% change of token price compared to a benchmark portfolio of 50% ETH and 50% BTC"
           />
         </VStack>

--- a/src/components/PercentageHeading.tsx
+++ b/src/components/PercentageHeading.tsx
@@ -1,0 +1,25 @@
+import { Heading } from "@chakra-ui/react"
+import { VFC } from "react"
+import { FaArrowDown, FaArrowUp } from "react-icons/fa"
+
+interface PercentageHeadingProps {
+  headingSize?: "sm" | "md" | "lg" | "xl"
+  arrow?: boolean
+  isDataNegative?: boolean | 0
+}
+
+export const PercentageHeading: VFC<PercentageHeadingProps> = ({
+  headingSize,
+  arrow,
+  isDataNegative,
+}) => {
+  return arrow ? (
+    isDataNegative ? (
+      <FaArrowDown />
+    ) : (
+      <FaArrowUp />
+    )
+  ) : (
+    <Heading size={headingSize}>{isDataNegative ? "-" : "+"}</Heading>
+  )
+}

--- a/src/components/PercentageText.tsx
+++ b/src/components/PercentageText.tsx
@@ -1,6 +1,6 @@
-import { Heading, HStack, Text } from "@chakra-ui/react"
+import { Heading, HStack } from "@chakra-ui/react"
 import { VFC } from "react"
-import { FaArrowDown, FaArrowUp } from "react-icons/fa"
+import { PercentageHeading } from "./PercentageHeading"
 
 interface PercentageTextProps {
   data?: number
@@ -27,18 +27,13 @@ export const PercentageText: VFC<PercentageTextProps> = ({
       }
       spacing={0}
     >
-      {!isDataZero &&
-        (isDataNegative ? (
-          arrow ? (
-            <FaArrowDown />
-          ) : (
-            <Heading size={headingSize}>-</Heading>
-          )
-        ) : arrow ? (
-          <FaArrowUp />
-        ) : (
-          <Heading size={headingSize}>+</Heading>
-        ))}
+      {!isDataZero && (
+        <PercentageHeading
+          headingSize={headingSize}
+          arrow={arrow}
+          isDataNegative={isDataNegative}
+        />
+      )}
 
       <Heading
         size={headingSize}

--- a/src/components/PercentageText.tsx
+++ b/src/components/PercentageText.tsx
@@ -1,15 +1,17 @@
-import { Heading, HStack } from "@chakra-ui/react"
+import { Heading, HStack, Text } from "@chakra-ui/react"
 import { VFC } from "react"
 import { FaArrowDown, FaArrowUp } from "react-icons/fa"
 
 interface PercentageTextProps {
   data?: number
   headingSize?: "sm" | "md" | "lg" | "xl"
+  arrow?: boolean
 }
 
 export const PercentageText: VFC<PercentageTextProps> = ({
   data,
   headingSize = "sm",
+  arrow,
 }) => {
   const isDataZero = data === 0
   const isDataNegative = data && data < 0
@@ -26,7 +28,18 @@ export const PercentageText: VFC<PercentageTextProps> = ({
       spacing={0}
     >
       {!isDataZero &&
-        (isDataNegative ? <FaArrowDown /> : <FaArrowUp />)}
+        (isDataNegative ? (
+          arrow ? (
+            <FaArrowDown />
+          ) : (
+            <Heading size={headingSize}>-</Heading>
+          )
+        ) : arrow ? (
+          <FaArrowUp />
+        ) : (
+          <Heading size={headingSize}>+</Heading>
+        ))}
+
       <Heading
         size={headingSize}
         display="flex"

--- a/src/components/_cards/CellarCard/AboutCellar.tsx
+++ b/src/components/_cards/CellarCard/AboutCellar.tsx
@@ -92,7 +92,7 @@ export const AboutCellar: React.FC<Props> = ({ data }) => {
               <Box>--</Box>
             )}
             <CellarStatsLabel
-              title="1M Change vs ETH/BTC 50/50"
+              title="1W Change vs ETH/BTC 50/50"
               tooltip="% change of token price compared to a benchmark portfolio of 50% ETH and 50% BTC"
             />
           </Flex>

--- a/src/components/_cards/CellarCard/AboutCellar.tsx
+++ b/src/components/_cards/CellarCard/AboutCellar.tsx
@@ -10,6 +10,7 @@ import {
   isAPYEnabled,
   isCurrentDepositsEnabled,
   isDailyChangeEnabled,
+  isIntervalGainPctEnabled,
   isTokenPriceEnabled,
   isTVMEnabled,
 } from "data/uiConfig"
@@ -83,7 +84,7 @@ export const AboutCellar: React.FC<Props> = ({ data }) => {
           </Flex>
         )}
 
-        {isTokenPriceEnabled(cellarConfig) && (
+        {isIntervalGainPctEnabled(cellarConfig) && (
           <Flex alignItems="center">
             {intervalGainPct.data ? (
               <PercentageText data={intervalGainPct.data} />

--- a/src/components/_cards/CellarCard/AboutCellar.tsx
+++ b/src/components/_cards/CellarCard/AboutCellar.tsx
@@ -20,6 +20,7 @@ import { CellarStats, CellarStatsLabel } from "./CellarStats"
 import { useDailyChange } from "data/hooks/useDailyChange"
 import { useTokenPrice } from "data/hooks/useTokenPrice"
 import { PercentageText } from "components/PercentageText"
+import { useIntervalGainPct } from "data/hooks/useIntervalGainPct"
 
 interface Props {
   data: CellarCardData
@@ -32,6 +33,7 @@ export const AboutCellar: React.FC<Props> = ({ data }) => {
   const { data: activeAsset } = useActiveAsset(cellarConfig)
   const { data: cellarCap } = useCellarCap(cellarConfig)
   const { data: currentDeposits } = useCurrentDeposits(cellarConfig)
+  const intervalGainPct = useIntervalGainPct(cellarConfig)
 
   const tokenPrice = useTokenPrice(cellarConfig)
   const dailyChange = useDailyChange(cellarConfig)
@@ -70,13 +72,27 @@ export const AboutCellar: React.FC<Props> = ({ data }) => {
         {isDailyChangeEnabled(cellarConfig) && (
           <Flex alignItems="center">
             {dailyChange.data ? (
-              <PercentageText data={dailyChange.data} />
+              <PercentageText data={dailyChange.data} arrow />
             ) : (
               <Box>--</Box>
             )}
             <CellarStatsLabel
               title="1D Change"
               tooltip="% change of current token price vs. token price yesterday"
+            />
+          </Flex>
+        )}
+
+        {isTokenPriceEnabled(cellarConfig) && (
+          <Flex alignItems="center">
+            {intervalGainPct.data ? (
+              <PercentageText data={intervalGainPct.data} />
+            ) : (
+              <Box>--</Box>
+            )}
+            <CellarStatsLabel
+              title="1M Change vs ETH/BTC 50/50"
+              tooltip="% change of token price compared to a benchmark portfolio of 50% ETH and 50% BTC"
             />
           </Flex>
         )}

--- a/src/components/_pages/PageCellar.tsx
+++ b/src/components/_pages/PageCellar.tsx
@@ -1,6 +1,5 @@
 import { VFC } from "react"
 import {
-  Box,
   Heading,
   HeadingProps,
   HStack,
@@ -98,7 +97,18 @@ const PageCellar: VFC<CellarPageProps> = ({ id }) => {
                       headingSize="md"
                     />
                   ) : (
-                    <Box>...</Box>
+                    <Spinner />
+                  )}
+                </>
+              }
+              changeVsEthBtcTooltip="1M Change vs ETH/BTC 50/50 - % change of token price compared to a benchmark portfolio of 50% ETH and 50% BTC"
+              changeVsEthBtcLabel="1M Change vs ETH/BTC 50/50"
+              changeVsEthBtcValue={
+                <>
+                  {dailyChange ? (
+                    <PercentageText data={0.43} headingSize="md" />
+                  ) : (
+                    <Spinner />
                   )}
                 </>
               }

--- a/src/components/_pages/PageCellar.tsx
+++ b/src/components/_pages/PageCellar.tsx
@@ -1,5 +1,6 @@
 import { VFC } from "react"
 import {
+  Box,
   Heading,
   HeadingProps,
   HStack,
@@ -27,6 +28,7 @@ import { useDailyChange } from "data/hooks/useDailyChange"
 import { PercentageText } from "components/PercentageText"
 import { CellarStatsAutomated } from "components/CellarStatsAutomated"
 import { CellarType } from "data/types"
+import { useIntervalGainPct } from "data/hooks/useIntervalGainPct"
 
 const h2Styles: HeadingProps = {
   as: "h2",
@@ -46,6 +48,7 @@ const PageCellar: VFC<CellarPageProps> = ({ id }) => {
   const { data: activeAsset } = useActiveAsset(cellarConfig)
   const { data: tokenPrice } = useTokenPrice(cellarConfig)
   const { data: dailyChange } = useDailyChange(cellarConfig)
+  const intervalGainPct = useIntervalGainPct(cellarConfig)
 
   return (
     <Layout>
@@ -95,20 +98,24 @@ const PageCellar: VFC<CellarPageProps> = ({ id }) => {
                     <PercentageText
                       data={dailyChange}
                       headingSize="md"
+                      arrow
                     />
                   ) : (
-                    <Spinner />
+                    <Box>...</Box>
                   )}
                 </>
               }
-              changeVsEthBtcTooltip="1M Change vs ETH/BTC 50/50 - % change of token price compared to a benchmark portfolio of 50% ETH and 50% BTC"
-              changeVsEthBtcLabel="1M Change vs ETH/BTC 50/50"
-              changeVsEthBtcValue={
+              monthChangeTooltip="% change of token price compared to a benchmark portfolio of 50% ETH and 50% BTC"
+              monthChangeLabel="1M Change vs ETH/BTC 50/50"
+              monthChangeValue={
                 <>
-                  {dailyChange ? (
-                    <PercentageText data={0.43} headingSize="md" />
+                  {intervalGainPct.data ? (
+                    <PercentageText
+                      data={intervalGainPct.data}
+                      headingSize="md"
+                    />
                   ) : (
-                    <Spinner />
+                    <Box>...</Box>
                   )}
                 </>
               }

--- a/src/components/_pages/PageCellar.tsx
+++ b/src/components/_pages/PageCellar.tsx
@@ -109,13 +109,13 @@ const PageCellar: VFC<CellarPageProps> = ({ id }) => {
               monthChangeLabel="1M Change vs ETH/BTC 50/50"
               monthChangeValue={
                 <>
-                  {intervalGainPct.data ? (
+                  {intervalGainPct.isLoading ? (
+                    <Spinner />
+                  ) : (
                     <PercentageText
                       data={intervalGainPct.data}
                       headingSize="md"
                     />
-                  ) : (
-                    <Box>...</Box>
                   )}
                 </>
               }

--- a/src/components/_pages/PageCellar.tsx
+++ b/src/components/_pages/PageCellar.tsx
@@ -106,7 +106,7 @@ const PageCellar: VFC<CellarPageProps> = ({ id }) => {
                 </>
               }
               monthChangeTooltip="% change of token price compared to a benchmark portfolio of 50% ETH and 50% BTC"
-              monthChangeLabel="1M Change vs ETH/BTC 50/50"
+              monthChangeLabel="1W Change vs ETH/BTC 50/50"
               monthChangeValue={
                 <>
                   {intervalGainPct.isLoading ? (

--- a/src/data/actions/common/getAssetIntervalGain.ts
+++ b/src/data/actions/common/getAssetIntervalGain.ts
@@ -13,10 +13,10 @@ export const getAssetIntervalGain = async (
       },
     })
     const data = await response.json()
-    const previousMonth = data.prices[0][1]
+    const previousWeek = data.prices[0][1]
     const getToday = data.prices[data.prices.length - 1][1]
 
-    const result = getGainPct(getToday, previousMonth)
+    const result = getGainPct(getToday, previousWeek)
 
     return result
   } catch (error) {

--- a/src/data/actions/common/getAssetIntervalGain.ts
+++ b/src/data/actions/common/getAssetIntervalGain.ts
@@ -13,8 +13,8 @@ export const getAssetIntervalGain = async (
       },
     })
     const data = await response.json()
-    const getToday = data.prices[0][1]
-    const previousMonth = data.prices[data.prices.length - 1][1]
+    const previousMonth = data.prices[0][1]
+    const getToday = data.prices[data.prices.length - 1][1]
 
     const result = getGainPct(getToday, previousMonth)
 

--- a/src/data/actions/common/getAssetIntervalGain.ts
+++ b/src/data/actions/common/getAssetIntervalGain.ts
@@ -1,0 +1,26 @@
+import { getGainPct } from "utils/getGainPct"
+
+export const getAssetIntervalGain = async (
+  asset: "wrapped-bitcoin" | "weth",
+  day: number
+) => {
+  const url = `https://api.coingecko.com/api/v3/coins/${asset}/market_chart?vs_currency=usd&days=${day}&interval=daily`
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+    const data = await response.json()
+    const getToday = data.prices[0][1]
+    const previousMonth = data.prices[data.prices.length - 1][1]
+
+    const result = getGainPct(getToday, previousMonth)
+
+    return result
+  } catch (error) {
+    console.warn("Cannot read cellar data", error)
+    throw error
+  }
+}

--- a/src/data/hooks/useBtcIntervalGain.ts
+++ b/src/data/hooks/useBtcIntervalGain.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query"
+import { getAssetIntervalGain } from "data/actions/common/getAssetIntervalGain"
+
+export const useBtcIntervalGain = (day: number) => {
+  const query = useQuery(
+    ["USE_BTC_INTERVAL_GAIN", day],
+    async () => {
+      return await getAssetIntervalGain("wrapped-bitcoin", day)
+    },
+    {
+      enabled: true,
+    }
+  )
+
+  return query
+}

--- a/src/data/hooks/useEthIntervalGain.ts
+++ b/src/data/hooks/useEthIntervalGain.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query"
+import { getAssetIntervalGain } from "data/actions/common/getAssetIntervalGain"
+
+export const useEthIntervalGain = (day: number) => {
+  const query = useQuery(
+    ["USE_ETH_INTERVAL_GAIN", day],
+    async () => {
+      return await getAssetIntervalGain("weth", day)
+    },
+    {
+      enabled: true,
+    }
+  )
+
+  return query
+}

--- a/src/data/hooks/useIntervalGainPct.ts
+++ b/src/data/hooks/useIntervalGainPct.ts
@@ -33,8 +33,9 @@ export const useIntervalGainPct = (config: ConfigProps) => {
   const { dayDatas: previousMonthDatas } = cellarPreviousMonth || {}
 
   const queryEnabled = Boolean(
-    todayDatas &&
-      previousMonthDatas &&
+    config.id &&
+      todayDatas?.[0].shareValue &&
+      previousMonthDatas?.[0].shareValue &&
       Boolean(ethIntervalGain.data) &&
       Boolean(btcIntervalGain.data)
   )
@@ -42,11 +43,11 @@ export const useIntervalGainPct = (config: ConfigProps) => {
   const query = useQuery(
     [
       "USE_INTERVAL_GAIN_PCT",
+      config.id,
       todayDatas,
       previousMonthDatas,
       ethIntervalGain.data,
       btcIntervalGain.data,
-      config.id,
     ],
     async () => {
       if (

--- a/src/data/hooks/useIntervalGainPct.ts
+++ b/src/data/hooks/useIntervalGainPct.ts
@@ -28,9 +28,9 @@ export const useIntervalGainPct = (config: ConfigProps) => {
   const { cellar: cellarToday } = dataToday || {}
   const { dayDatas: todayDatas } = cellarToday || {}
 
-  const { data: dataPreviousMonth } = previousWeekData
-  const { cellar: cellarPreviousMonth } = dataPreviousMonth || {}
-  const { dayDatas: previousWeekDatas } = cellarPreviousMonth || {}
+  const { data: dataPreviousWeek } = previousWeekData
+  const { cellar: cellarPreviousWeek } = dataPreviousWeek || {}
+  const { dayDatas: previousWeekDatas } = cellarPreviousWeek || {}
 
   const queryEnabled = Boolean(
     config.id &&

--- a/src/data/hooks/useIntervalGainPct.ts
+++ b/src/data/hooks/useIntervalGainPct.ts
@@ -1,0 +1,77 @@
+import { useQuery } from "@tanstack/react-query"
+import { ConfigProps } from "data/types"
+import { useGetSingleCellarValueQuery } from "generated/subgraph"
+import { getPreviousMonth, getToday } from "utils/calculateTime"
+import { getGainPct } from "utils/getGainPct"
+import { useBtcIntervalGain } from "./useBtcIntervalGain"
+import { useEthIntervalGain } from "./useEthIntervalGain"
+
+export const useIntervalGainPct = (config: ConfigProps) => {
+  const ethIntervalGain = useEthIntervalGain(30)
+  const btcIntervalGain = useBtcIntervalGain(30)
+
+  const [todayData] = useGetSingleCellarValueQuery({
+    variables: {
+      cellarAddress: config.id,
+      epoch: getToday(),
+    },
+  })
+
+  const [previousMonthData] = useGetSingleCellarValueQuery({
+    variables: {
+      cellarAddress: config.id,
+      epoch: getPreviousMonth(),
+    },
+  })
+
+  const { data: dataToday } = todayData
+  const { cellar: cellarToday } = dataToday || {}
+  const { dayDatas: todayDatas } = cellarToday || {}
+
+  const { data: dataPreviousMonth } = previousMonthData
+  const { cellar: cellarPreviousMonth } = dataPreviousMonth || {}
+  const { dayDatas: previousMonthDatas } = cellarPreviousMonth || {}
+
+  const queryEnabled = Boolean(
+    todayDatas &&
+      previousMonthDatas &&
+      Boolean(ethIntervalGain.data) &&
+      Boolean(btcIntervalGain.data)
+  )
+
+  const query = useQuery(
+    [
+      "USE_INTERVAL_GAIN_PCT",
+      todayDatas,
+      previousMonthDatas,
+      ethIntervalGain.data,
+      btcIntervalGain.data,
+      config.id,
+    ],
+    async () => {
+      if (
+        !todayDatas ||
+        !previousMonthDatas ||
+        !ethIntervalGain.data ||
+        !btcIntervalGain.data
+      ) {
+        throw new Error("DATA UNDEFINED")
+      }
+      const cellarIntervalGainPct = getGainPct(
+        Number(todayDatas[0].shareValue),
+        Number(previousMonthDatas[0].shareValue)
+      )
+
+      const result =
+        cellarIntervalGainPct -
+        (ethIntervalGain.data + btcIntervalGain.data) / 2
+
+      return result
+    },
+    {
+      enabled: queryEnabled,
+    }
+  )
+
+  return query
+}

--- a/src/data/hooks/useIntervalGainPct.ts
+++ b/src/data/hooks/useIntervalGainPct.ts
@@ -44,8 +44,8 @@ export const useIntervalGainPct = (config: ConfigProps) => {
     [
       "USE_INTERVAL_GAIN_PCT",
       config.id,
-      todayDatas,
-      previousMonthDatas,
+      todayDatas?.[0].shareValue,
+      previousMonthDatas?.[0].shareValue,
       ethIntervalGain.data,
       btcIntervalGain.data,
     ],

--- a/src/data/hooks/useIntervalGainPct.ts
+++ b/src/data/hooks/useIntervalGainPct.ts
@@ -1,14 +1,14 @@
 import { useQuery } from "@tanstack/react-query"
 import { ConfigProps } from "data/types"
 import { useGetSingleCellarValueQuery } from "generated/subgraph"
-import { getPreviousMonth, getToday } from "utils/calculateTime"
+import { getPreviousWeek, getToday } from "utils/calculateTime"
 import { getGainPct } from "utils/getGainPct"
 import { useBtcIntervalGain } from "./useBtcIntervalGain"
 import { useEthIntervalGain } from "./useEthIntervalGain"
 
 export const useIntervalGainPct = (config: ConfigProps) => {
-  const ethIntervalGain = useEthIntervalGain(30)
-  const btcIntervalGain = useBtcIntervalGain(30)
+  const ethIntervalGain = useEthIntervalGain(7)
+  const btcIntervalGain = useBtcIntervalGain(7)
 
   const [todayData] = useGetSingleCellarValueQuery({
     variables: {
@@ -17,10 +17,10 @@ export const useIntervalGainPct = (config: ConfigProps) => {
     },
   })
 
-  const [previousMonthData] = useGetSingleCellarValueQuery({
+  const [previousWeekData] = useGetSingleCellarValueQuery({
     variables: {
       cellarAddress: config.id,
-      epoch: getPreviousMonth(),
+      epoch: getPreviousWeek(),
     },
   })
 
@@ -28,14 +28,14 @@ export const useIntervalGainPct = (config: ConfigProps) => {
   const { cellar: cellarToday } = dataToday || {}
   const { dayDatas: todayDatas } = cellarToday || {}
 
-  const { data: dataPreviousMonth } = previousMonthData
+  const { data: dataPreviousMonth } = previousWeekData
   const { cellar: cellarPreviousMonth } = dataPreviousMonth || {}
-  const { dayDatas: previousMonthDatas } = cellarPreviousMonth || {}
+  const { dayDatas: previousWeekDatas } = cellarPreviousMonth || {}
 
   const queryEnabled = Boolean(
     config.id &&
       todayDatas?.[0].shareValue &&
-      previousMonthDatas?.[0].shareValue &&
+      previousWeekDatas?.[0].shareValue &&
       Boolean(ethIntervalGain.data) &&
       Boolean(btcIntervalGain.data)
   )
@@ -45,14 +45,14 @@ export const useIntervalGainPct = (config: ConfigProps) => {
       "USE_INTERVAL_GAIN_PCT",
       config.id,
       todayDatas?.[0].shareValue,
-      previousMonthDatas?.[0].shareValue,
+      previousWeekDatas?.[0].shareValue,
       ethIntervalGain.data,
       btcIntervalGain.data,
     ],
     async () => {
       if (
         !todayDatas ||
-        !previousMonthDatas ||
+        !previousWeekDatas ||
         !ethIntervalGain.data ||
         !btcIntervalGain.data
       ) {
@@ -60,7 +60,7 @@ export const useIntervalGainPct = (config: ConfigProps) => {
       }
       const cellarIntervalGainPct = getGainPct(
         Number(todayDatas[0].shareValue),
-        Number(previousMonthDatas[0].shareValue)
+        Number(previousWeekDatas[0].shareValue)
       )
 
       const result =

--- a/src/data/uiConfig.ts
+++ b/src/data/uiConfig.ts
@@ -32,6 +32,10 @@ export const isDailyChangeEnabled = (config: ConfigProps) => {
   return config.cellar.key === CellarKey.CLEAR_GATE_CELLAR
 }
 
+export const isIntervalGainPctEnabled = (config: ConfigProps) => {
+  return config.cellar.key === CellarKey.CLEAR_GATE_CELLAR
+}
+
 export const lpTokenTooltipContent = (config: ConfigProps) => {
   if (config.cellar.key === CellarKey.AAVE_V2_STABLE_CELLAR)
     return "Unbonded LP tokens earn interest from strategy but do not earn Liquidity Mining rewards"

--- a/src/generated/subgraph.ts
+++ b/src/generated/subgraph.ts
@@ -1686,7 +1686,7 @@ export function useGetPositionQuery(options: Omit<Urql.UseQueryArgs<GetPositionQ
 export const GetSingleCellarValueDocument = gql`
     query GetSingleCellarValue($epoch: Int!, $cellarAddress: ID!) {
   cellar(id: $cellarAddress) {
-    dayDatas(where: {date: $epoch}) {
+    dayDatas(first: 1, where: {date_gte: $epoch}) {
       date
       shareValue
     }

--- a/src/generated/subgraph.ts
+++ b/src/generated/subgraph.ts
@@ -1466,6 +1466,14 @@ export type GetPositionQueryVariables = Exact<{
 
 export type GetPositionQuery = { __typename?: 'Query', walletCellarData?: { __typename?: 'WalletCellarData', id: string, currentDeposits: string } | null };
 
+export type GetSingleCellarValueQueryVariables = Exact<{
+  epoch: Scalars['Int'];
+  cellarAddress: Scalars['ID'];
+}>;
+
+
+export type GetSingleCellarValueQuery = { __typename?: 'Query', cellar?: { __typename?: 'Cellar', dayDatas: Array<{ __typename?: 'CellarDayData', date: number, shareValue: string }> } | null };
+
 export type GetWeeklyTvlByAdressQueryVariables = Exact<{
   epoch: Scalars['Int'];
   cellarAddress: Scalars['ID'];
@@ -1674,6 +1682,20 @@ export const GetPositionDocument = gql`
 
 export function useGetPositionQuery(options: Omit<Urql.UseQueryArgs<GetPositionQueryVariables>, 'query'>) {
   return Urql.useQuery<GetPositionQuery>({ query: GetPositionDocument, ...options });
+};
+export const GetSingleCellarValueDocument = gql`
+    query GetSingleCellarValue($epoch: Int!, $cellarAddress: ID!) {
+  cellar(id: $cellarAddress) {
+    dayDatas(where: {date: $epoch}) {
+      date
+      shareValue
+    }
+  }
+}
+    `;
+
+export function useGetSingleCellarValueQuery(options: Omit<Urql.UseQueryArgs<GetSingleCellarValueQueryVariables>, 'query'>) {
+  return Urql.useQuery<GetSingleCellarValueQuery>({ query: GetSingleCellarValueDocument, ...options });
 };
 export const GetWeeklyTvlByAdressDocument = gql`
     query GetWeeklyTVLByAdress($epoch: Int!, $cellarAddress: ID!) {

--- a/src/queries/get-single-cellar-value.graphql
+++ b/src/queries/get-single-cellar-value.graphql
@@ -1,0 +1,8 @@
+query GetSingleCellarValue($epoch: Int!, $cellarAddress: ID!) {
+  cellar(id: $cellarAddress) {
+    dayDatas(where: { date: $epoch }) {
+      date
+      shareValue
+    }
+  }
+}

--- a/src/queries/get-single-cellar-value.graphql
+++ b/src/queries/get-single-cellar-value.graphql
@@ -1,6 +1,6 @@
 query GetSingleCellarValue($epoch: Int!, $cellarAddress: ID!) {
   cellar(id: $cellarAddress) {
-    dayDatas(where: { date: $epoch }) {
+    dayDatas(first: 1, where: { date_gte: $epoch }) {
       date
       shareValue
     }

--- a/src/utils/calculateTime.ts
+++ b/src/utils/calculateTime.ts
@@ -1,3 +1,12 @@
+export const getToday = () => {
+  const dayInSecs = 24 * 60 * 60
+  const now = new Date()
+  const today =
+    Math.floor(now.getTime() / 1000 / dayInSecs) * dayInSecs
+
+  return today
+}
+
 export const getPrevious24Hours = () => {
   const now = new Date()
   const last24HoursInSeconds = 24 * 60 * 60
@@ -14,4 +23,14 @@ export const getPreviousWeek = (): number => {
   const secondsSinceEpoch = Math.round(now.getTime() / 1000)
 
   return secondsSinceEpoch
+}
+
+export const getPreviousMonth = (): number => {
+  const dayInSecs = 24 * 60 * 60
+  const now = new Date()
+  const previousMonth =
+    Math.floor((now.getTime() - dayInSecs * 30) / 1000 / dayInSecs) *
+    dayInSecs
+
+  return previousMonth
 }

--- a/src/utils/calculateTime.ts
+++ b/src/utils/calculateTime.ts
@@ -1,8 +1,7 @@
 export const getToday = () => {
-  const dayInSecs = 24 * 60 * 60
+  const dayInMs = 24 * 60 * 60 * 1000
   const now = new Date()
-  const today =
-    Math.floor(now.getTime() / 1000 / dayInSecs) * dayInSecs
+  const today = (Math.floor(now.getTime() / dayInMs) * dayInMs) / 1000
 
   return today
 }
@@ -26,14 +25,11 @@ export const getPreviousWeek = (): number => {
 }
 
 export const getPreviousMonth = (): number => {
-  const dayInSecs = 24 * 60 * 60
+  const dayInMs = 24 * 60 * 60 * 1000
   const now = new Date()
   const previousMonth =
-    Math.floor(
-      (now.getTime() - dayInSecs * 30 * 1000) / 1000 / dayInSecs
-    ) *
-      dayInSecs +
-    dayInSecs * 3
+    (Math.floor((now.getTime() - dayInMs * 30) / dayInMs) * dayInMs) /
+    1000
 
   return previousMonth
 }

--- a/src/utils/calculateTime.ts
+++ b/src/utils/calculateTime.ts
@@ -29,8 +29,11 @@ export const getPreviousMonth = (): number => {
   const dayInSecs = 24 * 60 * 60
   const now = new Date()
   const previousMonth =
-    Math.floor((now.getTime() - dayInSecs * 30) / 1000 / dayInSecs) *
-    dayInSecs
+    Math.floor(
+      (now.getTime() - dayInSecs * 30 * 1000) / 1000 / dayInSecs
+    ) *
+      dayInSecs +
+    dayInSecs * 3
 
   return previousMonth
 }

--- a/src/utils/getGainPct.ts
+++ b/src/utils/getGainPct.ts
@@ -1,3 +1,3 @@
 export const getGainPct = (priceNow: number, priceBefore: number) => {
-  return (priceNow - priceBefore) / priceBefore
+  return ((priceNow - priceBefore) / priceBefore) * 100
 }

--- a/src/utils/getGainPct.ts
+++ b/src/utils/getGainPct.ts
@@ -1,0 +1,3 @@
+export const getGainPct = (priceNow: number, priceBefore: number) => {
+  return (priceNow - priceBefore) / priceBefore
+}


### PR DESCRIPTION
#588 

## Description

Add 1M Change vs ETH/BTC 50/50 for token price second design iteration

## Changes

List any technical changes.

- [x] [feat: create hooks for eth and btc interval gain](https://github.com/strangelove-ventures/sommelier/commit/29f2866a7b97428ecd77e1b0c745c8b249a0ace6)
- [x] [feat: create actions to get assets interval gain](https://github.com/strangelove-ventures/sommelier/commit/b4c003e2694b317a44dc97cae7a1dd4814738522)
- [x] [feat: create utils to get gain pct data](https://github.com/strangelove-ventures/sommelier/commit/13bebdec78bf2ab0f08a6e56b94fe6ea3710f8f2)
- [x] [feat: add get today and previous month](https://github.com/strangelove-ventures/sommelier/commit/56d936fc39f0cd7a541b4c6b17e0b600d418f73e)
- [x] [feat: create query to get single cellar value](https://github.com/strangelove-ventures/sommelier/commit/32c5b0ed81f2ccabc78d7746dd22eb22255237c9) 
- [x] [feat: getPreviousMonth calculation](https://github.com/strangelove-ventures/sommelier/commit/8f1c7ceaa925d148a35a0731a7df8f59ca4dc225) 
- [x] [feat: add intervalGainPct in about cellar](https://github.com/strangelove-ventures/sommelier/commit/e34c2a8d2e801b27f03df4cdcdad403fd96fad2e)
- [x] [feat: add intervalGainPct in page cellar](https://github.com/strangelove-ventures/sommelier/commit/ec278038dc25c4a05eb9ccbd8296926d23eeb2d7)
- [x] [feat: add intervalGainPct in hero section](https://github.com/strangelove-ventures/sommelier/commit/e82bca6ad3fb22c5616d85c5c16e1a399dcc825f)

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/43783037/200677940-e137b4ee-28f8-499d-966b-0b1c5a64535f.png)
![image](https://user-images.githubusercontent.com/43783037/200677995-2d86375a-ef46-4bb1-8702-73bbeac8e884.png)
![image](https://user-images.githubusercontent.com/43783037/200678024-33c4e511-51f2-43bf-8eab-55638c168080.png)



## Links
https://www.figma.com/file/7IAQbLyzapnrow9sIcO77P/App?node-id=2195:101054
