### PR TITLE
Feat/601 add tracking for strategies

### DIFF
--- a/src/components/HeroStrategy/hero-right.tsx
+++ b/src/components/HeroStrategy/hero-right.tsx
@@ -21,6 +21,8 @@ import { VFC } from "react"
 import { PercentageText } from "components/PercentageText"
 import { CellarStatsLabel } from "components/_cards/CellarCard/CellarStats"
 import { useTvm } from "data/hooks/useTvm"
+import { analytics } from "utils/analytics"
+import { landingType } from "utils/landingType"
 
 interface HeroStrategyRightProps {
   id: string
@@ -39,7 +41,17 @@ export const HeroStrategyRight: VFC<HeroStrategyRightProps> = ({
 
   return (
     <Stack minW={"280px"} spacing={4}>
-      <BaseButton w="full" h="50px" onClick={buyOrSellModal.onOpen}>
+      <BaseButton
+        w="full"
+        h="50px"
+        onClick={() => {
+          analytics.track("strategy.buy-sell", {
+            strategyCard: cellarData.name,
+            landingType: landingType(),
+          })
+          buyOrSellModal.onOpen()
+        }}
+      >
         Buy / Sell
       </BaseButton>
       <BuyOrSellModal
@@ -50,6 +62,12 @@ export const HeroStrategyRight: VFC<HeroStrategyRightProps> = ({
       />
       <Link
         href={`/strategies/${id}/manage`}
+        onClick={() => {
+          analytics.track("strategy.manage-portfolio", {
+            strategyCard: cellarData.name,
+            landingType: landingType(),
+          })
+        }}
         style={{ textDecoration: "none" }}
       >
         <SecondaryButton w="full" h="50px">

--- a/src/components/_modals/BuyOrSellModal.tsx
+++ b/src/components/_modals/BuyOrSellModal.tsx
@@ -7,6 +7,9 @@ import {
   Text,
 } from "@chakra-ui/react"
 import { ChevronRightIcon, ExternalLinkIcon } from "components/_icons"
+import { cellarDataMap } from "data/cellarDataMap"
+import { analytics } from "utils/analytics"
+import { landingType } from "utils/landingType"
 import { BaseModal } from "./BaseModal"
 
 interface BuyOrSellModalProps
@@ -39,6 +42,13 @@ export const BuyOrSellModal = ({
         {uniswapLink && (
           <Link
             href={uniswapLink}
+            onClick={() => {
+              analytics.track("strategy.buy-sell", {
+                strategyCard: cellarDataMap[id].name,
+                platformSelection: "Uniswap",
+                landingType: landingType(),
+              })
+            }}
             target="_blank"
             style={{ textDecoration: "none" }}
           >
@@ -67,6 +77,13 @@ export const BuyOrSellModal = ({
         )}
         <Link
           href={`/strategies/${id}/manage`}
+          onClick={() => {
+            analytics.track("strategy.buy-sell", {
+              strategyCard: cellarDataMap[id].name,
+              platformSelection: "Sommelier",
+              landingType: landingType(),
+            })
+          }}
           style={{ textDecoration: "none" }}
         >
           <HStack

--- a/src/components/_pages/PageHome.tsx
+++ b/src/components/_pages/PageHome.tsx
@@ -14,6 +14,8 @@ import FAQ from "components/FAQ"
 import { cellarDataMap } from "data/cellarDataMap"
 import { CellarType } from "data/types"
 import { config } from "utils/config"
+import { analytics } from "utils/analytics"
+import { landingType } from "utils/landingType"
 
 interface CellarGridItemsType {
   section: CellarType
@@ -46,6 +48,12 @@ const PageHome: NextPage<HomeProps> = ({ faqData }) => {
               key={cellar}
               display="flex"
               borderRadius={28}
+              onClick={() => {
+                analytics.track("strategy.selection", {
+                  strategyCard: cellarDataMap[cellar].name,
+                  landingType: landingType(),
+                })
+              }}
             >
               <CellarCard cellarAddress={cellar} as="li" />
             </Link>

--- a/src/utils/landingType.ts
+++ b/src/utils/landingType.ts
@@ -1,0 +1,7 @@
+export const landingType = () => {
+  const referrer = document.referrer
+  if (referrer === "" || !referrer) {
+    return "Direct"
+  }
+  return referrer
+}


### PR DESCRIPTION
Closes #601 

## Description

Add analytics for some actions in strategies related

## Changes

- [x] [chore: add utils for landingType](https://github.com/strangelove-ventures/sommelier/commit/821144b9535c89a6f32919a89069ac9b5cb2641b)
- [x] [feat(analytics): 601 add analytics for strategies](https://github.com/strangelove-ventures/sommelier/commit/369035b74aaa4a596ef0b79dc16da96820fe44dc)
