### PR TITLE
feat: comment out aave strategy apy

### DIFF
--- a/src/data/actions/AAVE_V2_STABLE_CELLAR/getApy.ts
+++ b/src/data/actions/AAVE_V2_STABLE_CELLAR/getApy.ts
@@ -53,11 +53,15 @@ export const getApy = async (
     const { expectedApy, formattedCellarApy, formattedStakingApy } =
       getExpectedApy(apy, potentialStakingApy)
 
-    const apyLabel = `Expected APY is calculated by combining the Base Cellar APY (${formattedCellarApy}%) and Liquidity Mining Rewards (${formattedStakingApy}%)`
+    // Comment out because of rebalancing, Aave APY is 0.00% for the week.
+    // const apyLabel = `Expected APY is calculated by combining the Base Cellar APY (${formattedCellarApy}%) and Liquidity Mining Rewards (${formattedStakingApy}%)`
+    const apyLabel = `Expected APY`
 
     return {
       apyLabel,
-      expectedApy: expectedApy.toFixed(1).toString() + "%",
+      // Comment out because of rebalancing, Aave APY is 0.00% for the week.
+      // expectedApy: expectedApy.toFixed(1).toString() + "%",
+      expectedApy: "1.9%",
     }
   } catch (error) {
     console.warn("Cannot read cellar data", error)


### PR DESCRIPTION
#628 

## Description

Comment out aave strategy apy, because of rebalancing, Aave APY is 0.00% for the week.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/43783037/201189082-6020216a-ca27-47a6-bb58-0c85c8cd1d18.png)
![image](https://user-images.githubusercontent.com/43783037/201189141-574f7f6c-1e9f-4109-99f5-1c8157a6bad3.png)

