### PR TITLE
update percentage text and icon

### DIFF
--- a/src/components/PercentageHeading.tsx
+++ b/src/components/PercentageHeading.tsx
@@ -1,15 +1,14 @@
-import { Heading } from "@chakra-ui/react"
 import { VFC } from "react"
 import { FaArrowDown, FaArrowUp } from "react-icons/fa"
+import { MinusIcon } from "./_icons/MinusIcon"
+import { PlusIcon } from "./_icons/PlusIcon"
 
 interface PercentageHeadingProps {
-  headingSize?: "sm" | "md" | "lg" | "xl"
   arrow?: boolean
   isDataNegative?: boolean | 0
 }
 
 export const PercentageHeading: VFC<PercentageHeadingProps> = ({
-  headingSize,
   arrow,
   isDataNegative,
 }) => {
@@ -19,7 +18,9 @@ export const PercentageHeading: VFC<PercentageHeadingProps> = ({
     ) : (
       <FaArrowUp />
     )
+  ) : isDataNegative ? (
+    <MinusIcon />
   ) : (
-    <Heading size={headingSize}>{isDataNegative ? "-" : "+"}</Heading>
+    <PlusIcon />
   )
 }

--- a/src/components/PercentageText.tsx
+++ b/src/components/PercentageText.tsx
@@ -13,7 +13,8 @@ export const PercentageText: VFC<PercentageTextProps> = ({
   headingSize = "sm",
   arrow,
 }) => {
-  const isDataZero = data === 0
+  const percentageData = data && Math.abs(data).toFixed(2)
+  const isDataZero = Number(percentageData) === 0
   const isDataNegative = data && data < 0
 
   return (
@@ -29,7 +30,6 @@ export const PercentageText: VFC<PercentageTextProps> = ({
     >
       {!isDataZero && (
         <PercentageHeading
-          headingSize={headingSize}
           arrow={arrow}
           isDataNegative={isDataNegative}
         />
@@ -41,7 +41,7 @@ export const PercentageText: VFC<PercentageTextProps> = ({
         alignItems="center"
         columnGap="3px"
       >
-        {(data && Math.abs(data).toFixed(2)) || "--"}%
+        {percentageData || "--"}%
       </Heading>
     </HStack>
   )

--- a/src/components/_icons/MinusIcon.tsx
+++ b/src/components/_icons/MinusIcon.tsx
@@ -1,0 +1,14 @@
+import { Icon, IconProps } from "@chakra-ui/react"
+import { VFC } from "react"
+
+export const MinusIcon: VFC<IconProps> = (props) => (
+  <Icon viewBox="0 0 14 12" {...props}>
+    <path
+      d="M1.428 6h11.143"
+      stroke="#F2574D"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </Icon>
+)

--- a/src/components/_icons/PlusIcon.tsx
+++ b/src/components/_icons/PlusIcon.tsx
@@ -1,0 +1,14 @@
+import { Icon, IconProps } from "@chakra-ui/react"
+import { VFC } from "react"
+
+export const PlusIcon: VFC<IconProps> = (props) => (
+  <Icon viewBox="0 0 14 14" {...props}>
+    <path
+      d="M7 1.463v11.143M1.428 7h11.143"
+      stroke="#BCE051"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </Icon>
+)


### PR DESCRIPTION
#632 

## Description

Implement design feedback for percentage text

## Changes

List any technical changes.

- [x] add plus and minus icon
- [x] update percentage text to be neural if displayed value is 0

## Screenshots (if appropriate):

positive value
![image](https://user-images.githubusercontent.com/43783037/201781852-5378ade1-4295-4eee-a80e-c879d1d2b501.png)

negative value
![image](https://user-images.githubusercontent.com/43783037/201781965-7c38e1c4-aa4f-4c01-aa52-f1e282b7ed4a.png)


