### PR TITLE
Feat(eth btc chart)/change comparation to first data

### DIFF
--- a/src/components/PercentageText.tsx
+++ b/src/components/PercentageText.tsx
@@ -16,6 +16,7 @@ export const PercentageText: VFC<PercentageTextProps> = ({
   const percentageData = data && Math.abs(data).toFixed(2)
   const isDataZero = Number(percentageData) === 0
   const isDataNegative = data && data < 0
+  const valueExists: boolean = isDataZero || Boolean(percentageData)
   return (
     <HStack
       color={
@@ -39,7 +40,7 @@ export const PercentageText: VFC<PercentageTextProps> = ({
         alignItems="center"
         columnGap="3px"
       >
-        {isDataZero || percentageData ? percentageData : "--"}%
+        {valueExists ? percentageData : "--"}%
       </Heading>
     </HStack>
   )

--- a/src/components/PercentageText.tsx
+++ b/src/components/PercentageText.tsx
@@ -16,7 +16,6 @@ export const PercentageText: VFC<PercentageTextProps> = ({
   const percentageData = data && Math.abs(data).toFixed(2)
   const isDataZero = Number(percentageData) === 0
   const isDataNegative = data && data < 0
-
   return (
     <HStack
       color={
@@ -40,7 +39,7 @@ export const PercentageText: VFC<PercentageTextProps> = ({
         alignItems="center"
         columnGap="3px"
       >
-        {percentageData || "--"}%
+        {isDataZero || percentageData ? percentageData : "--"}%
       </Heading>
     </HStack>
   )

--- a/src/components/_charts/EthBtcChart.tsx
+++ b/src/components/_charts/EthBtcChart.tsx
@@ -42,11 +42,13 @@ export const EthBtcChart: VFC = () => {
   const updateTokenPriceChange = ({ data: point, id }: Point) => {
     const [_, i] = id.split(".")
     const tokenPriceChange = data.series?.[0].data[Number(i)]?.y
+    const valueExists: boolean =
+      Boolean(tokenPriceChange) || String(tokenPriceChange) === "0"
     setTokenPriceChange({
       xFormatted: point.xFormatted,
       yFormatted: `
         ${
-          tokenPriceChange || String(tokenPriceChange) === "0"
+          valueExists
             ? formatPercentage(String(tokenPriceChange))
             : "--"
         }`,

--- a/src/components/_charts/EthBtcChart.tsx
+++ b/src/components/_charts/EthBtcChart.tsx
@@ -46,7 +46,7 @@ export const EthBtcChart: VFC = () => {
       xFormatted: point.xFormatted,
       yFormatted: `
         ${
-          tokenPriceChange
+          tokenPriceChange || String(tokenPriceChange) === "0"
             ? formatPercentage(String(tokenPriceChange))
             : "--"
         }`,

--- a/src/data/actions/common/getEthBtcGainChartData.ts
+++ b/src/data/actions/common/getEthBtcGainChartData.ts
@@ -20,11 +20,11 @@ export const getEthBtcGainChartData = async (
         change: number
       }[] = []
       wethData.prices.map(([date, value], index) => {
-        const prevData = wethData.prices[index - 1]
-        if (prevData) {
+        const firstData = wethData.prices[0]
+        if (firstData) {
           res.push({
             date,
-            change: getGainPct(value, prevData[1]),
+            change: getGainPct(value, firstData[1]),
           })
         }
       })
@@ -37,11 +37,11 @@ export const getEthBtcGainChartData = async (
         change: number
       }[] = []
       wbtcData.prices.map(([date, value], index) => {
-        const prevData = wbtcData.prices[index - 1]
-        if (prevData) {
+        const firstData = wbtcData.prices[0]
+        if (firstData) {
           res.push({
             date,
-            change: getGainPct(value, prevData[1]),
+            change: getGainPct(value, firstData[1]),
           })
         }
       })
@@ -56,8 +56,8 @@ export const getEthBtcGainChartData = async (
         interval === "daily"
           ? wbtcGainPct.find((item) =>
               isSameDay(new Date(item.date), new Date(weth.date))
-            )
-          : wbtcGainPct[index]
+            ) // daily
+          : wbtcGainPct[index] //hourly
       if (wbtc) {
         wethDatum.push({
           x: new Date(weth.date),

--- a/src/data/context/ethBtcChartContext.tsx
+++ b/src/data/context/ethBtcChartContext.tsx
@@ -155,7 +155,7 @@ export const EthBtcChartProvider: FC<{
 }> = ({ children, address }) => {
   // GQL Queries
   const [
-    { fetching: hourlyIsFetching, data: hourlyData },
+    { fetching: hourlyIsFetching, data: hourlyDataRaw },
     reexecuteHourly,
   ] = useGetHourlyShareValueQuery({
     variables: {
@@ -164,7 +164,7 @@ export const EthBtcChartProvider: FC<{
     },
   })
   const [
-    { fetching: weeklyIsFetching, data: weeklyData },
+    { fetching: weeklyIsFetching, data: weeklyDataRaw },
     reexecuteWeekly,
   ] = useGetWeeklyShareValueQuery({
     variables: {
@@ -173,7 +173,7 @@ export const EthBtcChartProvider: FC<{
     },
   })
   const [
-    { fetching: monthlyIsFetching, data: monthlyData },
+    { fetching: monthlyIsFetching, data: monthlyDataRaw },
     reexecuteMonthly,
   ] = useGetMonthlyShareValueQuery({
     variables: {
@@ -182,24 +182,22 @@ export const EthBtcChartProvider: FC<{
     },
   })
   const [
-    { fetching: allTimeIsFetching, data: allTimeData },
+    { fetching: allTimeIsFetching, data: allTimeDataRaw },
     reexecuteAllTime,
   ] = useGetAllTimeShareValueQuery({
     variables: {
       cellarAddress: address,
     },
   })
+  const hourlyData = hourlyDataRaw?.cellarHourDatas
+  const weeklyData = weeklyDataRaw?.cellar?.dayDatas
+  const monthlyData = monthlyDataRaw?.cellar?.dayDatas
+  const allTimeData = allTimeDataRaw?.cellar?.dayDatas
 
   const ethBtcHourly = useEthBtcGainChartData(1, "hourly")
-  const ethBtcHWeekly = useEthBtcGainChartData(
-    weeklyData?.cellar?.dayDatas.length
-  )
-  const ethBtcMonthly = useEthBtcGainChartData(
-    monthlyData?.cellar?.dayDatas.length
-  )
-  const ethBtcAlltime = useEthBtcGainChartData(
-    allTimeData?.cellar?.dayDatas.length
-  )
+  const ethBtcHWeekly = useEthBtcGainChartData(weeklyData?.length)
+  const ethBtcMonthly = useEthBtcGainChartData(monthlyData?.length)
+  const ethBtcAlltime = useEthBtcGainChartData(allTimeData?.length)
 
   // Set data to be returned by hook
   const [data, setData] = useState<DataProps>({
@@ -224,7 +222,7 @@ export const EthBtcChartProvider: FC<{
   // Functions to update data returned by hook
   const setDataHourly = () => {
     const tokenPriceDatum = createTokenPriceChangeDatum(
-      hourlyData?.cellarHourDatas.map((item) => {
+      hourlyData?.map((item) => {
         return {
           date: item.date,
           shareValue: item.shareValue,
@@ -253,7 +251,7 @@ export const EthBtcChartProvider: FC<{
   }
   const setDataWeekly = () => {
     const tokenPriceDatum = createTokenPriceChangeDatum(
-      weeklyData?.cellar?.dayDatas.map((item) => {
+      weeklyData?.map((item) => {
         return {
           date: item.date,
           shareValue: item.shareValue,
@@ -282,7 +280,7 @@ export const EthBtcChartProvider: FC<{
   }
   const setDataMonthly = () => {
     const tokenPriceDatum = createTokenPriceChangeDatum(
-      monthlyData?.cellar?.dayDatas.map((item) => {
+      monthlyData?.map((item) => {
         return {
           date: item.date,
           shareValue: item.shareValue,
@@ -310,7 +308,7 @@ export const EthBtcChartProvider: FC<{
   }
   const setDataAllTime = () => {
     const tokenPriceDatum = createTokenPriceChangeDatum(
-      allTimeData?.cellar?.dayDatas.map((item) => {
+      allTimeData?.map((item) => {
         return {
           date: item.date,
           shareValue: item.shareValue,
@@ -358,18 +356,16 @@ export const EthBtcChartProvider: FC<{
     const idIsDefault: boolean =
       data?.series![0].id === defaultSerieId
     if (weeklyData && idIsDefault && ethBtcHWeekly.data) {
-      const latestData =
-        weeklyData.cellar?.dayDatas[
-          weeklyData.cellar?.dayDatas.length - 1
-        ]
-      const tokenPriceDatum = createTokenPriceChangeDatum(
-        weeklyData?.cellar?.dayDatas.map((item) => {
-          return {
-            date: item.date,
-            shareValue: item.shareValue,
-          }
-        })
-      )
+      const latestData = weeklyData[weeklyData.length - 1]
+      const weeklyDataMap = weeklyData?.map((item) => {
+        return {
+          date: item.date,
+          shareValue: item.shareValue,
+        }
+      })
+      const tokenPriceDatum =
+        createTokenPriceChangeDatum(weeklyDataMap)
+
       setData({
         series: createEthBtcChartSeries({
           tokenPrice: tokenPriceDatum,

--- a/src/data/context/ethBtcChartContext.tsx
+++ b/src/data/context/ethBtcChartContext.tsx
@@ -398,14 +398,11 @@ export const EthBtcChartProvider: FC<{
         hour12: false,
       })
 
-      const before =
-        weeklyData.cellar?.dayDatas[
-          weeklyData.cellar?.dayDatas.length - 2
-        ].shareValue
+      const firstData = weeklyData[0].shareValue
 
       const change =
-        ((toInteger(latestData?.shareValue) - toInteger(before)) /
-          toInteger(before)) *
+        ((toInteger(latestData?.shareValue) - toInteger(firstData)) /
+          toInteger(firstData)) *
         100
 
       const latestTokenPriceChange = `${formatPercentage(

--- a/src/utils/chartHelper.ts
+++ b/src/utils/chartHelper.ts
@@ -26,13 +26,13 @@ export const createTokenPriceChangeDatum = (
   if (!data) return
 
   let datum: Datum[] = []
-  data.map((item, index) => {
-    const before = data[index - 1]
-    if (before) {
+  data.map((item, index, arr) => {
+    const firstData = data[0]
+    if (firstData) {
       const current = item.shareValue
-      const change = before
-        ? ((toInteger(current) - toInteger(before.shareValue)) /
-            toInteger(before.shareValue)) *
+      const change = firstData
+        ? ((toInteger(current) - toInteger(firstData.shareValue)) /
+            toInteger(firstData.shareValue)) *
           100
         : 0
       datum.push({


### PR DESCRIPTION
ETH BTC Chart

## Description

The right calculation for percentage on the chart is compared to the first data not the previous data 

## Changes

- [x] [feat: change comparation to the first data](https://github.com/strangelove-ventures/sommelier/commit/5013f5c4781806b34b4f77b42e0403c29fb34c8a)
- [x] [refactor: improve variable assignment](https://github.com/strangelove-ventures/sommelier/commit/9e26d8bfb9fc3b1a770069f45d2f01e7a974597a)
- [x] [fix: 0 value not showing](https://github.com/strangelove-ventures/sommelier/commit/8533cd4fc8441a4afd6aabee7ad28a84e0eba5c0)

## Screenshots:

![image](https://user-images.githubusercontent.com/39829726/202001770-1cb964f7-cc92-4bbe-b86e-6cb1a8af0bbb.png)
![image](https://user-images.githubusercontent.com/39829726/202001802-fc73df7c-f5c1-45f0-8cc9-15957a83e113.png)
