### PR TITLE
feat: first responsive iteration

### DIFF
--- a/src/components/CellarStatsAutomated.tsx
+++ b/src/components/CellarStatsAutomated.tsx
@@ -63,10 +63,8 @@ export const CellarStatsAutomated: VFC<CellarStatsAutomatedProps> = ({
       justifyContent={{ base: "space-between", md: "unset" }}
       divider={
         <CardDivider
-          css={{
-            _last: {
-              borderColor,
-            },
+          _last={{
+            borderColor,
           }}
         />
       }

--- a/src/components/CellarStatsAutomated.tsx
+++ b/src/components/CellarStatsAutomated.tsx
@@ -56,14 +56,15 @@ export const CellarStatsAutomated: VFC<CellarStatsAutomatedProps> = ({
 
   return (
     <HStack
-      spacing={8}
-      wrap="wrap"
+      spacing={{ base: 2, md: 8 }}
       rowGap={4}
       align="start"
+      w={{ base: "full", md: "auto" }}
+      justifyContent={{ base: "space-between", md: "unset" }}
       divider={
         <CardDivider
           css={{
-            "&:nth-last-of-type(2)": {
+            "&:nth-last-of-type(1)": {
               borderColor,
             },
           }}
@@ -107,7 +108,7 @@ export const CellarStatsAutomated: VFC<CellarStatsAutomatedProps> = ({
           </Tooltip>
         </Box>
       </VStack>
-      <VStack spacing={1} align="center" w="7rem">
+      <VStack spacing={1} align="center" maxW="7rem">
         {monthChangeValue}
         <Box
           onMouseEnter={debounce(() => {

--- a/src/components/CellarStatsAutomated.tsx
+++ b/src/components/CellarStatsAutomated.tsx
@@ -64,7 +64,7 @@ export const CellarStatsAutomated: VFC<CellarStatsAutomatedProps> = ({
       divider={
         <CardDivider
           css={{
-            "&:nth-last-of-type(1)": {
+            _last: {
               borderColor,
             },
           }}

--- a/src/components/CellarStatsYield.tsx
+++ b/src/components/CellarStatsYield.tsx
@@ -58,7 +58,7 @@ export const CellarStatsYield: VFC<CellarStatsYieldProps> = ({
       divider={
         <CardDivider
           css={{
-            "&:nth-last-of-type(1)": {
+            _last: {
               borderColor,
             },
           }}

--- a/src/components/CellarStatsYield.tsx
+++ b/src/components/CellarStatsYield.tsx
@@ -57,10 +57,8 @@ export const CellarStatsYield: VFC<CellarStatsYieldProps> = ({
       justifyContent={{ base: "space-between", md: "unset" }}
       divider={
         <CardDivider
-          css={{
-            _last: {
-              borderColor,
-            },
+          _last={{
+            borderColor,
           }}
         />
       }

--- a/src/components/CellarStatsYield.tsx
+++ b/src/components/CellarStatsYield.tsx
@@ -51,13 +51,14 @@ export const CellarStatsYield: VFC<CellarStatsYieldProps> = ({
 
   return (
     <HStack
-      spacing={8}
-      wrap="wrap"
+      spacing={{ base: 2, md: 8 }}
       rowGap={4}
+      w={{ base: "full", md: "auto" }}
+      justifyContent={{ base: "space-between", md: "unset" }}
       divider={
         <CardDivider
           css={{
-            "&:nth-last-of-type(2)": {
+            "&:nth-last-of-type(1)": {
               borderColor,
             },
           }}
@@ -65,7 +66,7 @@ export const CellarStatsYield: VFC<CellarStatsYieldProps> = ({
       }
       {...rest}
     >
-      <VStack spacing={1} align="flex-start">
+      <VStack spacing={1} align="center">
         <Text as="span" fontSize="21px" fontWeight="bold">
           {tvm}
         </Text>
@@ -82,7 +83,7 @@ export const CellarStatsYield: VFC<CellarStatsYieldProps> = ({
           </HStack>
         </Tooltip>
       </VStack>
-      <VStack spacing={1} align="flex-start">
+      <VStack spacing={1} align="center">
         <Apy apy={overrideApy?.value || apy} />
         <Box
           onMouseEnter={debounce(() => {

--- a/src/components/HeroStrategy/hero-right.tsx
+++ b/src/components/HeroStrategy/hero-right.tsx
@@ -92,7 +92,11 @@ export const HeroStrategyRight: VFC<HeroStrategyRightProps> = ({
 
         <VStack flex={1}>
           {dailyChange && (
-            <PercentageText data={dailyChange} headingSize="md" />
+            <PercentageText
+              data={dailyChange}
+              headingSize="md"
+              arrow
+            />
           )}
           <CellarStatsLabel
             tooltip="% change of current token price vs. token price yesterday"

--- a/src/components/HeroStrategy/hero-right.tsx
+++ b/src/components/HeroStrategy/hero-right.tsx
@@ -83,7 +83,7 @@ export const HeroStrategyRight: VFC<HeroStrategyRightProps> = ({
         divider={<StackDivider borderColor="purple.dark" />}
       >
         <VStack flex={1}>
-          <Heading size="md">{tokenPrice || <Spinner />}</Heading>
+          <Heading size="md">{tokenPrice || "--"}</Heading>
           <CellarStatsLabel
             tooltip="The dollar value of the ETH, BTC, and USDC that 1 token can be redeemed for"
             title="Token Price"
@@ -91,12 +91,14 @@ export const HeroStrategyRight: VFC<HeroStrategyRightProps> = ({
         </VStack>
 
         <VStack flex={1}>
-          {dailyChange && (
+          {dailyChange ? (
             <PercentageText
               data={dailyChange}
               headingSize="md"
               arrow
             />
+          ) : (
+            <Box>--</Box>
           )}
           <CellarStatsLabel
             tooltip="% change of current token price vs. token price yesterday"
@@ -105,11 +107,13 @@ export const HeroStrategyRight: VFC<HeroStrategyRightProps> = ({
         </VStack>
 
         <VStack flex={1} textAlign="center">
-          {intervalGainPct.data && (
+          {intervalGainPct.data ? (
             <PercentageText
               data={intervalGainPct.data}
               headingSize="md"
             />
+          ) : (
+            <Box>--</Box>
           )}
           <CellarStatsLabel
             title="1W Change vs ETH/BTC 50/50"

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -17,29 +17,33 @@ export const Layout: VFC<FlexProps> = ({ children, ...rest }) => {
 
   const router = useRouter()
 
-  const isHomeOrStrategiesLandingPage =
-    router.pathname === "/" ||
-    (router.pathname.includes("strategies") &&
-      !router.pathname.includes("manage"))
+  const isNotBridge =
+    router.pathname === "/" || router.pathname.includes("strategies")
 
   return (
     <Box>
       <MobileWarningCTA
         display={{
-          base: isHomeOrStrategiesLandingPage ? "none" : "flex",
+          base: isNotBridge ? "none" : "flex",
           md: "none",
         }}
       />
       <Box
         display={{
-          base: isHomeOrStrategiesLandingPage ? "block" : "none",
+          base: isNotBridge ? "block" : "none",
           md: "block",
         }}
       >
         <BackgroundAssets />
         <Flex minH="100vh" flexDir="column" {...rest}>
           <Nav />
-          <Container as="main" flex={1} pt={40} maxW="container.lg">
+          <Container
+            as="main"
+            flex={1}
+            pt={40}
+            maxW="container.lg"
+            px={{ base: 0, sm: 4 }}
+          >
             {isRestricted && <GeoBanner />}
             {isConnected && chain?.id !== 1 && <WrongNetworkBanner />}
             {children}

--- a/src/components/StrategyProvider.tsx
+++ b/src/components/StrategyProvider.tsx
@@ -1,14 +1,16 @@
 import {
   Avatar,
   HStack,
+  Icon,
   Text,
   Tooltip,
   VStack,
 } from "@chakra-ui/react"
 import { CellarDataMap } from "data/types"
 import { VFC } from "react"
+import { FaExternalLinkAlt } from "react-icons/fa"
 import { Link } from "./Link"
-import { ExternalLinkIcon, InformationIcon } from "./_icons"
+import { InformationIcon } from "./_icons"
 import { CardHeading } from "./_typography/CardHeading"
 
 export type StrategyProviderProps = Pick<
@@ -43,29 +45,13 @@ export const StrategyProvider: VFC<StrategyProviderProps> = ({
           <InformationIcon boxSize="12px" />
         </HStack>
       )}
-      <HStack>
+      <HStack as={Link} href={href} isExternal>
         {logo && <Avatar src={logo} size="xs" />}
         <Text as="span" fontWeight="bold" fontSize={21}>
           {title}
         </Text>
+        <Icon as={FaExternalLinkAlt} color="purple.base" />
       </HStack>
-      <Link
-        href={href}
-        isExternal
-        _hover={{
-          textDecoration: "underline",
-        }}
-      >
-        <HStack role="group" align="center">
-          <Text>Visit Website</Text>{" "}
-          <ExternalLinkIcon
-            color="purple.base"
-            _groupHover={{
-              color: "neutral.100",
-            }}
-          />
-        </HStack>
-      </Link>
     </VStack>
   )
 }

--- a/src/components/_cards/EthBtcPerfomanceCard.tsx
+++ b/src/components/_cards/EthBtcPerfomanceCard.tsx
@@ -3,6 +3,7 @@ import {
   BoxProps,
   Button,
   HStack,
+  Stack,
   Text,
   VStack,
 } from "@chakra-ui/react"
@@ -26,9 +27,14 @@ export const EthBtcPerfomanceCard: VFC<BoxProps> = (props) => {
   const [timeline, setTimeline] = useState<string>("1W")
 
   return (
-    <TransparentCard p={8} overflow="visible" {...props}>
+    <TransparentCard
+      px={{ base: 6, sm: 6, md: 8 }}
+      py={{ base: 6, md: 8 }}
+      overflow="visible"
+      {...props}
+    >
       <VStack spacing={6} align="stretch">
-        <Box h="20rem" mb={{ sm: "2.2rem", md: 0 }}>
+        <Box h="20rem" mb={{ base: 12, sm: "2.2rem", md: 0 }}>
           <HStack
             justify="space-between"
             align="flex-start"
@@ -92,7 +98,10 @@ export const EthBtcPerfomanceCard: VFC<BoxProps> = (props) => {
           </HStack>
           <EthBtcChart />
         </Box>
-        <HStack spacing={6}>
+        <Stack
+          direction={{ base: "column", md: "row" }}
+          spacing={{ base: 2, md: 4 }}
+        >
           <Legend
             color="purple.base"
             title={cellarDataMap[id].name}
@@ -100,7 +109,7 @@ export const EthBtcPerfomanceCard: VFC<BoxProps> = (props) => {
           <Legend color="violet.base" title="ETH 50/BTC 50" />
           <Legend color="turquoise.base" title="ETH" />
           <Legend color="orange.base" title="BTC" />
-        </HStack>
+        </Stack>
       </VStack>
     </TransparentCard>
   )

--- a/src/components/_cards/PerformanceCard.tsx
+++ b/src/components/_cards/PerformanceCard.tsx
@@ -19,7 +19,12 @@ export const PerformanceCard: VFC<BoxProps> = (props) => {
   const [timeline, setTimeline] = useState<string>("Day")
 
   return (
-    <TransparentCard p={8} overflow="visible" {...props}>
+    <TransparentCard
+      px={{ base: 0, sm: 6, md: 8 }}
+      py={{ base: 6, md: 8 }}
+      overflow="visible"
+      {...props}
+    >
       <VStack spacing={6} align="stretch" divider={<CardDivider />}>
         <Box h="20rem" mb={{ sm: "2.2rem", md: 0 }}>
           <HStack
@@ -27,6 +32,7 @@ export const PerformanceCard: VFC<BoxProps> = (props) => {
             align="flex-start"
             wrap="wrap"
             rowGap={2}
+            px={{ base: 6, sm: 0 }}
           >
             <HStack spacing={8}>
               <VStack spacing={0} align="flex-start">
@@ -77,7 +83,9 @@ export const PerformanceCard: VFC<BoxProps> = (props) => {
               })}
             </HStack>
           </HStack>
-          <TVLChart />
+          <Box h="90%">
+            <TVLChart />
+          </Box>
         </Box>
       </VStack>
     </TransparentCard>

--- a/src/components/_cards/StrategyBreakdownCard/index.tsx
+++ b/src/components/_cards/StrategyBreakdownCard/index.tsx
@@ -27,9 +27,19 @@ export const StrategyBreakdownCard: VFC<StrategyBreakdownProps> = ({
   const { strategyBreakdown, faq } = cellarDataMap[cellarId]
 
   return (
-    <InnerCard pt={4} px={6} pb={8}>
+    <InnerCard
+      pt={4}
+      px={6}
+      pb={8}
+      borderRadius={{ base: 0, sm: 16 }}
+    >
       <Tabs>
-        <TabList borderBottomWidth={1} borderColor="purple.dark">
+        <TabList
+          borderBottomWidth={1}
+          borderColor="purple.dark"
+          overflowX="auto"
+          overflowY="hidden"
+        >
           {Object.keys(strategyBreakdown).map((key) => {
             return (
               <Tab

--- a/src/components/_cards/TransparentCard.tsx
+++ b/src/components/_cards/TransparentCard.tsx
@@ -7,7 +7,7 @@ export const TransparentCard: VFC<BoxProps> = (props) => {
     <Card
       bg="surface.primary"
       borderWidth={1}
-      borderRadius={24}
+      borderRadius={{ base: 0, sm: 24 }}
       borderColor="surface.secondary"
       backdropFilter="blur(8px)"
       {...props}

--- a/src/components/_charts/EthBtcChart.tsx
+++ b/src/components/_charts/EthBtcChart.tsx
@@ -72,7 +72,7 @@ export const EthBtcChart: VFC = () => {
         ]),
       ]}
       fill={[{ match: "*", id: "gradientA" }]}
-      margin={{ bottom: 110, left: 20, right: 6, top: 20 }}
+      margin={{ bottom: 110, left: 25, right: 6, top: 20 }}
       theme={chartTheme}
       tooltip={ToolTip}
       yScale={{

--- a/src/components/_charts/TVLChart.tsx
+++ b/src/components/_charts/TVLChart.tsx
@@ -1,4 +1,4 @@
-import { Circle } from "@chakra-ui/react"
+import { Circle, useMediaQuery } from "@chakra-ui/react"
 import { linearGradientDef } from "@nivo/core"
 import { PointTooltipProps, Point } from "@nivo/line"
 import { useNivoThemes } from "hooks/nivo"
@@ -40,6 +40,7 @@ export const TVLChart: VFC = () => {
     })
   }
   const debouncedTvl = debounce(updateTvl, 100)
+  const [isLarger768] = useMediaQuery("(min-width: 768px)")
 
   return (
     <LineChart
@@ -56,7 +57,12 @@ export const TVLChart: VFC = () => {
         ]),
       ]}
       fill={[{ match: "*", id: "gradientA" }]}
-      margin={{ bottom: 110, left: 6, right: 6, top: 20 }}
+      margin={{
+        bottom: 110,
+        left: isLarger768 ? 6 : 24,
+        right: 24,
+        top: 20,
+      }}
       axisLeft={null}
       theme={chartTheme}
       tooltip={ToolTip}

--- a/src/components/_layout/Section.tsx
+++ b/src/components/_layout/Section.tsx
@@ -1,6 +1,6 @@
-import { Box, BoxProps } from '@chakra-ui/react'
-import { VFC } from 'react'
+import { Box, BoxProps } from "@chakra-ui/react"
+import { VFC } from "react"
 
-export const Section: VFC<BoxProps> = props => {
-  return <Box as='section' pb={12} {...props} />
+export const Section: VFC<BoxProps> = (props) => {
+  return <Box as="section" pb={12} px={4} {...props} />
 }

--- a/src/components/_pages/PageCellar.tsx
+++ b/src/components/_pages/PageCellar.tsx
@@ -5,6 +5,7 @@ import {
   HeadingProps,
   HStack,
   Spinner,
+  useMediaQuery,
   VStack,
 } from "@chakra-ui/react"
 import { Layout } from "components/Layout"
@@ -14,7 +15,6 @@ import CellarDetailsCard from "components/_cards/CellarDetailsCard"
 import { CellarStatsYield } from "components/CellarStatsYield"
 import { BreadCrumb } from "components/BreadCrumb"
 import { cellarDataMap } from "data/cellarDataMap"
-import { CoinImage } from "components/_cards/CellarCard/CoinImage"
 import { PerformanceChartByAddressProvider } from "data/context/performanceChartByAddressContext"
 import { useTvm } from "data/hooks/useTvm"
 import { useApy } from "data/hooks/useApy"
@@ -29,15 +29,14 @@ import { PercentageText } from "components/PercentageText"
 import { CellarStatsAutomated } from "components/CellarStatsAutomated"
 import { CellarType } from "data/types"
 import { useIntervalGainPct } from "data/hooks/useIntervalGainPct"
+import { isEthBtcChartEnabled } from "data/uiConfig"
 import { EthBtcChartProvider } from "data/context/ethBtcChartContext"
 import { EthBtcPerfomanceCard } from "components/_cards/EthBtcPerfomanceCard"
-import { isEthBtcChartEnabled } from "data/uiConfig"
-
 const h2Styles: HeadingProps = {
   as: "h2",
   fontSize: "2xl",
   color: "neutral.300",
-  pl: 8,
+  pl: { base: 6, sm: 8 },
 }
 
 const PageCellar: VFC<CellarPageProps> = ({ id }) => {
@@ -52,13 +51,17 @@ const PageCellar: VFC<CellarPageProps> = ({ id }) => {
   const { data: tokenPrice } = useTokenPrice(cellarConfig)
   const { data: dailyChange } = useDailyChange(cellarConfig)
   const intervalGainPct = useIntervalGainPct(cellarConfig)
+  const [isLarger768] = useMediaQuery("(min-width: 768px)")
+  const isYieldStrategies =
+    staticCellarData.cellarType === CellarType.yieldStrategies
+  const isAutomatedPortfolio =
+    staticCellarData.cellarType === CellarType.automatedPortfolio
 
   return (
     <Layout>
       <Section>
         <HStack
-          spacing={4}
-          pb={12}
+          pb={isLarger768 ? 12 : 0}
           justify="space-between"
           align="flex-end"
           wrap="wrap"
@@ -67,14 +70,12 @@ const PageCellar: VFC<CellarPageProps> = ({ id }) => {
           <VStack spacing={6} align="flex-start">
             <BreadCrumb cellarName={staticCellarData.name} id={id} />
             <HStack spacing={4}>
-              <CoinImage />
               <Heading fontSize="2.5rem">
                 {staticCellarData.name}{" "}
               </Heading>
             </HStack>
           </VStack>
-          {staticCellarData.cellarType ===
-            CellarType.yieldStrategies && (
+          {isYieldStrategies && (
             <CellarStatsYield
               tvm={tvm ? `${tvm.formatted}` : <Spinner />}
               apy={apyLoading ? <Spinner /> : apy?.expectedApy}
@@ -87,8 +88,7 @@ const PageCellar: VFC<CellarPageProps> = ({ id }) => {
             />
           )}
 
-          {staticCellarData.cellarType ===
-            CellarType.automatedPortfolio && (
+          {isAutomatedPortfolio && (
             <CellarStatsAutomated
               tokenPriceTooltip="The dollar value of the ETH, BTC, and USDC that 1 token can be redeemed for"
               tokenPriceLabel="Token price"
@@ -129,23 +129,27 @@ const PageCellar: VFC<CellarPageProps> = ({ id }) => {
             />
           )}
         </HStack>
-        <VStack spacing={4} align="stretch">
-          <Heading {...h2Styles}>Your Portfolio</Heading>
-          <PortfolioCard />
-        </VStack>
+        {isLarger768 && (
+          <VStack spacing={4} align="stretch">
+            <Heading {...h2Styles} pt={12}>
+              Your Portfolio
+            </Heading>
+            <PortfolioCard />
+          </VStack>
+        )}
       </Section>
-      <Section>
+      <Section px={{ base: 0, md: 4 }}>
         <VStack spacing={6} align="stretch">
+          VStack{" "}
           {isEthBtcChartEnabled(cellarConfig) && (
             <EthBtcChartProvider address={cellarAddress}>
-              <Heading pt={12} {...h2Styles}>
+              <Heading pt={isLarger768 ? 12 : 0} {...h2Styles}>
                 Strategy Perfomance
               </Heading>
               <EthBtcPerfomanceCard />
             </EthBtcChartProvider>
           )}
-
-          <Heading pt={12} {...h2Styles}>
+          <Heading pt={isYieldStrategies ? 0 : 12} {...h2Styles}>
             Strategy Details
           </Heading>
           <CellarDetailsCard

--- a/src/components/_pages/PageHome.tsx
+++ b/src/components/_pages/PageHome.tsx
@@ -116,7 +116,9 @@ const PageHome: NextPage<HomeProps> = ({ faqData }) => {
           </Flex>
         </Section>
       </VStack>
-      <FAQ data={faqData.faqTabs} />
+      <Section pb="0">
+        <FAQ data={faqData.faqTabs} />
+      </Section>
     </Layout>
   )
 }

--- a/src/components/_pages/PageStrategy.tsx
+++ b/src/components/_pages/PageStrategy.tsx
@@ -14,7 +14,7 @@ export const PageStrategy: NextPage<StrategyLandingPageProps> = ({
   sectionStrategies,
 }) => {
   return (
-    <Layout>
+    <Layout px={4}>
       <HeroStrategy id={id} />
       <Highlight id={id} />
       <Cellars data={sectionCellars} mt={52} />

--- a/src/components/_pages/PageStrategy.tsx
+++ b/src/components/_pages/PageStrategy.tsx
@@ -1,3 +1,4 @@
+import { Box } from "@chakra-ui/react"
 import { Cellars } from "components/Cellars"
 import { FAQStrategy } from "components/FAQStrategy"
 import { HeroStrategy } from "components/HeroStrategy"
@@ -14,12 +15,14 @@ export const PageStrategy: NextPage<StrategyLandingPageProps> = ({
   sectionStrategies,
 }) => {
   return (
-    <Layout px={4}>
-      <HeroStrategy id={id} />
-      <Highlight id={id} />
-      <Cellars data={sectionCellars} mt={52} />
-      <Strategy data={sectionStrategies} mt={52} />
-      <FAQStrategy data={faqData} mt={52} />
+    <Layout>
+      <Box px={{ base: 4, sm: 0 }}>
+        <HeroStrategy id={id} />
+        <Highlight id={id} />
+        <Cellars data={sectionCellars} mt={52} />
+        <Strategy data={sectionStrategies} mt={52} />
+        <FAQStrategy data={faqData} mt={52} />
+      </Box>
     </Layout>
   )
 }


### PR DESCRIPTION
#356 

## Description

Working on the first responsive iteration for strategy detail page, update "Explore strategies button" to open in the same page, update Icon in strategy landing page hero section

## Changes

List any technical changes.

- [x] not display "your portofolio" section in strategy detail page on mobile view
- [x] update charts to support mobile view
- [x] update components to support mobile design first iteration
- [x] update Icon in strategy landing page hero section
- [x] update "Explore strategies button" to open in the same page 

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/43783037/202045274-20098598-75b1-49bf-b275-4da7bd7b8cbe.png)
![image](https://user-images.githubusercontent.com/43783037/202045310-abda0e15-0f3e-44d7-9c98-c0918eefbfb5.png)
![image](https://user-images.githubusercontent.com/43783037/202045336-69182fbc-89a3-433e-b660-d7fe7fd1d99d.png)
![image](https://user-images.githubusercontent.com/43783037/202045366-653cc21d-689a-4a77-892b-d5a696e5bf67.png)
