### PR TITLE
Fix/weekly change calculation

### DIFF
--- a/src/data/actions/common/getEthBtcGainChartData.ts
+++ b/src/data/actions/common/getEthBtcGainChartData.ts
@@ -84,69 +84,35 @@ export const getEthBtcGainChartData = async (
             wethGainPct.map((item) => new Date(item.date))
           )!
         ]
+      const getKey = (date: number) =>
+        format(new Date(date), interval === "daily" ? "dLL" : "dHH")
       if (wbtc) {
-        if (
-          !wethMap.has(
-            format(
-              new Date(weth.date),
-              interval === "daily" ? "dLL" : "dHH"
-            )
-          )
-        ) {
-          wethMap.set(
-            interval === "daily"
-              ? format(new Date(weth.date), "dLL")
-              : format(new Date(weth.date), "dHH"),
-            {
-              x: isDaily
-                ? subDays(new Date(weth.date), 1)
-                : new Date(weth.date),
-              y: weth.change,
-              value: weth.value,
-            }
-          )
+        if (!wethMap.has(getKey(weth.date))) {
+          wethMap.set(getKey(weth.date), {
+            x: isDaily
+              ? subDays(new Date(weth.date), 1)
+              : new Date(weth.date),
+            y: weth.change,
+            value: weth.value,
+          })
         }
-        if (
-          !wbtcMap.has(
-            format(
-              new Date(wbtc.date),
-              interval === "daily" ? "dLL" : "dHH"
-            )
-          )
-        ) {
-          wbtcMap.set(
-            interval === "daily"
-              ? format(new Date(wbtc.date), "dLL")
-              : format(new Date(wbtc.date), "dHH"),
-            {
-              x: isDaily
-                ? subDays(new Date(wbtc.date), 1)
-                : new Date(wbtc.date),
-              y: wbtc.change,
-              value: wbtc.value,
-            }
-          )
+        if (!wbtcMap.has(getKey(wbtc.date))) {
+          wbtcMap.set(getKey(wbtc.date), {
+            x: isDaily
+              ? subDays(new Date(wbtc.date), 1)
+              : new Date(wbtc.date),
+            y: wbtc.change,
+            value: wbtc.value,
+          })
         }
-        if (
-          !wethWbtcMap.has(
-            format(
-              new Date(weth.date),
-              interval === "daily" ? "dLL" : "dHH"
-            )
-          )
-        ) {
-          wethWbtcMap.set(
-            interval === "daily"
-              ? format(new Date(weth.date), "dLL")
-              : format(new Date(weth.date), "dHH"),
-            {
-              x: isDaily
-                ? subDays(new Date(weth.date), 1)
-                : new Date(weth.date),
-              y: (weth.change + wbtc.change) / 2,
-              value: (weth.value + wbtc.value) / 2,
-            }
-          )
+        if (!wethWbtcMap.has(getKey(weth.date))) {
+          wethWbtcMap.set(getKey(weth.date), {
+            x: isDaily
+              ? subDays(new Date(weth.date), 1)
+              : new Date(weth.date),
+            y: (weth.change + wbtc.change) / 2,
+            value: (weth.value + wbtc.value) / 2,
+          })
         }
       }
     })

--- a/src/data/actions/common/getEthBtcGainChartData.ts
+++ b/src/data/actions/common/getEthBtcGainChartData.ts
@@ -85,42 +85,69 @@ export const getEthBtcGainChartData = async (
           )!
         ]
       if (wbtc) {
-        wethMap.set(
-          interval === "daily"
-            ? format(new Date(weth.date), "dLL")
-            : format(new Date(weth.date), "dHH"),
-          {
-            x: isDaily
-              ? subDays(new Date(weth.date), 1)
-              : new Date(weth.date),
-            y: weth.change,
-            value: weth.value,
-          }
-        )
-        wbtcMap.set(
-          interval === "daily"
-            ? format(new Date(wbtc.date), "dLL")
-            : format(new Date(wbtc.date), "dHH"),
-          {
-            x: isDaily
-              ? subDays(new Date(wbtc.date), 1)
-              : new Date(wbtc.date),
-            y: wbtc.change,
-            value: wbtc.value,
-          }
-        )
-        wethWbtcMap.set(
-          interval === "daily"
-            ? format(new Date(weth.date), "dLL")
-            : format(new Date(weth.date), "dHH"),
-          {
-            x: isDaily
-              ? subDays(new Date(weth.date), 1)
-              : new Date(weth.date),
-            y: (weth.change + wbtc.change) / 2,
-            value: (weth.value + wbtc.value) / 2,
-          }
-        )
+        if (
+          !wethMap.has(
+            format(
+              new Date(weth.date),
+              interval === "daily" ? "dLL" : "dHH"
+            )
+          )
+        ) {
+          wethMap.set(
+            interval === "daily"
+              ? format(new Date(weth.date), "dLL")
+              : format(new Date(weth.date), "dHH"),
+            {
+              x: isDaily
+                ? subDays(new Date(weth.date), 1)
+                : new Date(weth.date),
+              y: weth.change,
+              value: weth.value,
+            }
+          )
+        }
+        if (
+          !wbtcMap.has(
+            format(
+              new Date(wbtc.date),
+              interval === "daily" ? "dLL" : "dHH"
+            )
+          )
+        ) {
+          wbtcMap.set(
+            interval === "daily"
+              ? format(new Date(wbtc.date), "dLL")
+              : format(new Date(wbtc.date), "dHH"),
+            {
+              x: isDaily
+                ? subDays(new Date(wbtc.date), 1)
+                : new Date(wbtc.date),
+              y: wbtc.change,
+              value: wbtc.value,
+            }
+          )
+        }
+        if (
+          !wethWbtcMap.has(
+            format(
+              new Date(weth.date),
+              interval === "daily" ? "dLL" : "dHH"
+            )
+          )
+        ) {
+          wethWbtcMap.set(
+            interval === "daily"
+              ? format(new Date(weth.date), "dLL")
+              : format(new Date(weth.date), "dHH"),
+            {
+              x: isDaily
+                ? subDays(new Date(weth.date), 1)
+                : new Date(weth.date),
+              y: (weth.change + wbtc.change) / 2,
+              value: (weth.value + wbtc.value) / 2,
+            }
+          )
+        }
       }
     })
 

--- a/src/data/actions/common/getWeeklyAssetIntervalGain.ts
+++ b/src/data/actions/common/getWeeklyAssetIntervalGain.ts
@@ -1,4 +1,3 @@
-import { addWeeks, subDays } from "date-fns"
 import { getGainPct } from "utils/getGainPct"
 import { fetchMarketChart } from "./fetchMarketChart"
 
@@ -8,11 +7,10 @@ export const getWeeklyAssetIntervalGain = async (
   day: number
 ) => {
   try {
-    const data = await fetchMarketChart(asset, 6, "daily")
+    const data = await fetchMarketChart(asset, day, "daily")
 
     const previousWeek = data.prices[0]
     // today
-    const today = subDays(addWeeks(new Date(previousWeek[0]), 1), 1)
     const todayData = data.prices.at(-2)
     if (!todayData) throw new Error("todayData undefined")
     const result = getGainPct(todayData![1], previousWeek[1])

--- a/src/data/actions/common/getWeeklyAssetIntervalGain.ts
+++ b/src/data/actions/common/getWeeklyAssetIntervalGain.ts
@@ -13,7 +13,7 @@ export const getWeeklyAssetIntervalGain = async (
     // coingecko returns the latest date with 2 hour value, 00:00 data and latest hour data. We get the 00:00 value with length - 2 index
     const todayData = data.prices.at(-2)
     if (!todayData) throw new Error("todayData undefined")
-    const result = getGainPct(todayData![1], previousWeek[1])
+    const result = getGainPct(todayData[1], previousWeek[1])
 
     return result
   } catch (error) {

--- a/src/data/actions/common/getWeeklyAssetIntervalGain.ts
+++ b/src/data/actions/common/getWeeklyAssetIntervalGain.ts
@@ -10,7 +10,7 @@ export const getWeeklyAssetIntervalGain = async (
     const data = await fetchMarketChart(asset, day, "daily")
 
     const previousWeek = data.prices[0]
-    // today
+    // coingecko returns the latest date with 2 hour value, 00:00 data and latest hour data. We get the 00:00 value with length - 2 index
     const todayData = data.prices.at(-2)
     if (!todayData) throw new Error("todayData undefined")
     const result = getGainPct(todayData![1], previousWeek[1])

--- a/src/data/actions/common/getWeeklyAssetIntervalGain.ts
+++ b/src/data/actions/common/getWeeklyAssetIntervalGain.ts
@@ -1,4 +1,4 @@
-import { addWeeks, isSameDay, subDays } from "date-fns"
+import { addWeeks, subDays } from "date-fns"
 import { getGainPct } from "utils/getGainPct"
 import { fetchMarketChart } from "./fetchMarketChart"
 
@@ -8,16 +8,13 @@ export const getWeeklyAssetIntervalGain = async (
   day: number
 ) => {
   try {
-    const data = await fetchMarketChart(asset, day, "daily")
+    const data = await fetchMarketChart(asset, 6, "daily")
 
     const previousWeek = data.prices[0]
     // today
     const today = subDays(addWeeks(new Date(previousWeek[0]), 1), 1)
-    const todayData = data.prices.find(([date]) => {
-      return isSameDay(new Date(date), today)
-    })
-
-    if (!todayData) throw new Error("nextWeekData undefined")
+    const todayData = data.prices.at(-2)
+    if (!todayData) throw new Error("todayData undefined")
     const result = getGainPct(todayData![1], previousWeek[1])
 
     return result

--- a/src/data/actions/common/getWeeklyAssetIntervalGain.ts
+++ b/src/data/actions/common/getWeeklyAssetIntervalGain.ts
@@ -8,10 +8,10 @@ export const getWeeklyAssetIntervalGain = async (
 ) => {
   try {
     const data = await fetchMarketChart(asset, day, "daily")
-
     const previousWeek = data.prices[0]
     // coingecko returns the latest date with 2 hour value, 00:00 data and latest hour data. We get the 00:00 value with length - 2 index
-    const todayData = data.prices.at(-2)
+    const todayIndex = data.prices.length === day + 1 ? -2 : -1
+    const todayData = data.prices.at(todayIndex)
     if (!todayData) throw new Error("todayData undefined")
     const result = getGainPct(todayData[1], previousWeek[1])
 

--- a/src/data/context/ethBtcChartContext.tsx
+++ b/src/data/context/ethBtcChartContext.tsx
@@ -264,42 +264,43 @@ export const EthBtcChartProvider: FC<{
         }
       })
     )
-    setData({
-      series: createEthBtcChartSeries({
-        tokenPrice: tokenPriceDatum,
-        ethBtc50: ethBtcHourly.data?.wethWbtcdatum.slice(
-          0,
-          tokenPriceDatum?.length
-        ),
-        weth: ethBtcHourly.data?.wethDatum.slice(
-          0,
-          tokenPriceDatum?.length
-        ),
-        wbtc: ethBtcHourly.data?.wbtcDatum.slice(
-          0,
-          tokenPriceDatum?.length
-        ),
-      }),
 
+    const series = createEthBtcChartSeries({
+      tokenPrice: tokenPriceDatum,
+      ethBtc50: ethBtcHourly.data?.wethWbtcdatum.slice(
+        0,
+        tokenPriceDatum?.length
+      ),
+      weth: ethBtcHourly.data?.wethDatum.slice(
+        0,
+        tokenPriceDatum?.length
+      ),
+      wbtc: ethBtcHourly.data?.wbtcDatum.slice(
+        0,
+        tokenPriceDatum?.length
+      ),
+    })
+    setData({
+      series,
       chartProps: hourlyChartProps,
     })
+    const latestData = series[0].data.at(-1)
+    const firstData = series[0].data.at(0)
 
     const valueExists: boolean =
-      Boolean(tokenPriceDatum?.at(-1)?.y) ||
-      String(tokenPriceDatum?.at(-1)?.y) === "0"
+      Boolean(latestData?.y) || String(latestData?.y) === "0"
+
     const dateText = `${format(
-      new Date(String(tokenPriceDatum?.at(0)?.x)),
+      new Date(String(firstData?.x)),
       "HH:mm d MMM"
     )} - ${format(
-      new Date(String(tokenPriceDatum?.at(-1)?.x)),
+      new Date(String(latestData?.x)),
       "HH:mm d MMM yyyy"
     )}`
     setTokenPriceChange({
       xFormatted: dateText,
       yFormatted: `${
-        valueExists
-          ? formatPercentage(String(tokenPriceDatum?.at(-1)?.y))
-          : "--"
+        valueExists ? formatPercentage(String(latestData?.y)) : "--"
       }`,
     })
   }
@@ -312,44 +313,43 @@ export const EthBtcChartProvider: FC<{
         }
       })
     )
-    setData({
-      series: createEthBtcChartSeries({
-        tokenPrice: tokenPriceDatum,
-        ethBtc50: ethBtcHWeekly.data?.wethWbtcdatum.slice(
-          0,
-          tokenPriceDatum?.length
-        ),
-        weth: ethBtcHWeekly.data?.wethDatum.slice(
-          0,
-          tokenPriceDatum?.length
-        ),
-        wbtc: ethBtcHWeekly.data?.wbtcDatum.slice(
-          0,
-          tokenPriceDatum?.length
-        ),
-      }),
 
+    const series = createEthBtcChartSeries({
+      tokenPrice: tokenPriceDatum,
+      ethBtc50: ethBtcHWeekly.data?.wethWbtcdatum.slice(
+        0,
+        tokenPriceDatum?.length
+      ),
+      weth: ethBtcHWeekly.data?.wethDatum.slice(
+        0,
+        tokenPriceDatum?.length
+      ),
+      wbtc: ethBtcHWeekly.data?.wbtcDatum.slice(
+        0,
+        tokenPriceDatum?.length
+      ),
+    })
+    setData({
+      series,
       chartProps: dayChartProps,
     })
+    const latestData = series[0].data.at(-1)
+    const firstData = series[0].data.at(0)
+
     const valueExists: boolean =
-      Boolean(tokenPriceDatum?.at(-1)?.y) ||
-      String(tokenPriceDatum?.at(-1)?.y) === "0"
+      Boolean(latestData?.y) || String(latestData?.y) === "0"
     const dateText = `${format(
-      new Date(String(tokenPriceDatum?.at(0)?.x)),
+      new Date(String(firstData?.x)),
       "d MMM"
-    )} - ${format(
-      new Date(tokenPriceDatum?.at(-1)?.x!),
-      "d MMM yyyy"
-    )}`
+    )} - ${format(new Date(latestData?.x!), "d MMM yyyy")}`
     setTokenPriceChange({
       xFormatted: dateText,
       yFormatted: `${
-        valueExists
-          ? formatPercentage(String(tokenPriceDatum?.at(-1)?.y))
-          : "--"
+        valueExists ? formatPercentage(String(firstData?.y)) : "--"
       }`,
     })
   }
+
   const setDataMonthly = () => {
     const tokenPriceDatum = createTokenPriceChangeDatum(
       monthlyData?.map((item) => {
@@ -359,43 +359,43 @@ export const EthBtcChartProvider: FC<{
         }
       })
     )
+    const series = createEthBtcChartSeries({
+      tokenPrice: tokenPriceDatum,
+      ethBtc50: ethBtcMonthly.data?.wethWbtcdatum.slice(
+        0,
+        tokenPriceDatum?.length
+      ),
+      weth: ethBtcMonthly.data?.wethDatum.slice(
+        0,
+        tokenPriceDatum?.length
+      ),
+      wbtc: ethBtcMonthly.data?.wbtcDatum.slice(
+        0,
+        tokenPriceDatum?.length
+      ),
+    })
     setData({
-      series: createEthBtcChartSeries({
-        tokenPrice: tokenPriceDatum,
-        ethBtc50: ethBtcMonthly.data?.wethWbtcdatum.slice(
-          0,
-          tokenPriceDatum?.length
-        ),
-        weth: ethBtcMonthly.data?.wethDatum.slice(
-          0,
-          tokenPriceDatum?.length
-        ),
-        wbtc: ethBtcMonthly.data?.wbtcDatum.slice(
-          0,
-          tokenPriceDatum?.length
-        ),
-      }),
+      series,
       chartProps: monthChartProps,
     })
+
+    const latestData = series[0].data.at(-1)
+    const firstData = series[0].data.at(0)
+
     const valueExists: boolean =
-      Boolean(tokenPriceDatum?.at(-1)?.y) ||
-      String(tokenPriceDatum?.at(-1)?.y) === "0"
+      Boolean(latestData?.y) || String(latestData?.y) === "0"
     const dateText = `${format(
-      new Date(String(tokenPriceDatum?.at(0)?.x)),
+      new Date(String(firstData?.x)),
       "d MMM"
-    )} - ${format(
-      new Date(String(tokenPriceDatum?.at(-1)?.x)),
-      "d MMM yyyy"
-    )}`
+    )} - ${format(new Date(String(latestData?.x)), "d MMM yyyy")}`
     setTokenPriceChange({
       xFormatted: dateText,
       yFormatted: `${
-        valueExists
-          ? formatPercentage(String(tokenPriceDatum?.at(-1)?.y))
-          : "--"
+        valueExists ? formatPercentage(String(latestData?.y)) : "--"
       }`,
     })
   }
+
   const setDataAllTime = () => {
     const tokenPriceDatum = createTokenPriceChangeDatum(
       allTimeData?.map((item) => {
@@ -405,40 +405,39 @@ export const EthBtcChartProvider: FC<{
         }
       })
     )
+    const series = createEthBtcChartSeries({
+      tokenPrice: tokenPriceDatum,
+      ethBtc50: ethBtcAlltime.data?.wethWbtcdatum.slice(
+        0,
+        tokenPriceDatum?.length
+      ),
+      weth: ethBtcAlltime.data?.wethDatum.slice(
+        0,
+        tokenPriceDatum?.length
+      ),
+      wbtc: ethBtcAlltime.data?.wbtcDatum.slice(
+        0,
+        tokenPriceDatum?.length
+      ),
+    })
     setData({
-      series: createEthBtcChartSeries({
-        tokenPrice: tokenPriceDatum,
-        ethBtc50: ethBtcAlltime.data?.wethWbtcdatum.slice(
-          0,
-          tokenPriceDatum?.length
-        ),
-        weth: ethBtcAlltime.data?.wethDatum.slice(
-          0,
-          tokenPriceDatum?.length
-        ),
-        wbtc: ethBtcAlltime.data?.wbtcDatum.slice(
-          0,
-          tokenPriceDatum?.length
-        ),
-      }),
+      series,
       chartProps: allTimeChartProps,
     })
+
+    const latestData = series[0].data.at(-1)
+    const firstData = series[0].data.at(0)
+
     const valueExists: boolean =
-      Boolean(tokenPriceDatum?.at(-1)?.y) ||
-      String(tokenPriceDatum?.at(-1)?.y) === "0"
+      Boolean(latestData?.y) || String(latestData?.y) === "0"
     const dateText = `${format(
-      new Date(String(tokenPriceDatum?.at(0)?.x)),
+      new Date(String(firstData?.x)),
       "d MMM yyyy"
-    )} - ${format(
-      new Date(String(tokenPriceDatum?.at(-1)?.x)),
-      "d MMM yyyy"
-    )}`
+    )} - ${format(new Date(String(latestData?.x)), "d MMM yyyy")}`
     setTokenPriceChange({
       xFormatted: dateText,
       yFormatted: `${
-        valueExists
-          ? formatPercentage(String(tokenPriceDatum?.at(-1)?.y))
-          : "--"
+        valueExists ? formatPercentage(String(latestData?.y)) : "--"
       }`,
     })
   }

--- a/src/data/context/ethBtcChartContext.tsx
+++ b/src/data/context/ethBtcChartContext.tsx
@@ -304,6 +304,7 @@ export const EthBtcChartProvider: FC<{
       }`,
     })
   }
+
   const setDataWeekly = () => {
     const tokenPriceDatum = createTokenPriceChangeDatum(
       weeklyData?.map((item) => {
@@ -333,19 +334,23 @@ export const EthBtcChartProvider: FC<{
       series,
       chartProps: dayChartProps,
     })
-    const latestData = series[0].data.at(-1)
-    const firstData = series[0].data.at(0)
+    const latestData = series![0].data.at(-1)
+    const firstData = series![0].data.at(0)
 
-    const valueExists: boolean =
-      Boolean(latestData?.y) || String(latestData?.y) === "0"
+    const latestDate = format(
+      new Date(String(latestData?.x)),
+      "d MMM yyyy"
+    )
     const dateText = `${format(
       new Date(String(firstData?.x)),
       "d MMM"
-    )} - ${format(new Date(latestData?.x!), "d MMM yyyy")}`
+    )} - ${latestDate}`
+    const valueExists: boolean =
+      Boolean(latestData?.y) || String(latestData?.y) === "0"
     setTokenPriceChange({
       xFormatted: dateText,
       yFormatted: `${
-        valueExists ? formatPercentage(String(firstData?.y)) : "--"
+        valueExists ? formatPercentage(String(latestData?.y)) : "--"
       }`,
     })
   }

--- a/src/data/hooks/useIntervalGainPct.ts
+++ b/src/data/hooks/useIntervalGainPct.ts
@@ -8,8 +8,8 @@ import { useEthIntervalGain } from "./useEthIntervalGain"
 
 export const useIntervalGainPct = (config: ConfigProps) => {
   // Shift back coingecko by 1 day is intentional
-  const ethIntervalGain = useEthIntervalGain(7)
-  const btcIntervalGain = useBtcIntervalGain(7)
+  const ethIntervalGain = useEthIntervalGain(6)
+  const btcIntervalGain = useBtcIntervalGain(6)
 
   const [todayData] = useGetSingleCellarValueQuery({
     variables: {
@@ -64,13 +64,10 @@ export const useIntervalGainPct = (config: ConfigProps) => {
         Number(previousWeekDatas[0].shareValue)
       )
 
-      console.log(new Date(previousWeekDatas[0].date * 1000))
-      console.log(new Date(todayDatas[0].date * 1000))
       const result =
         cellarIntervalGainPct -
         (ethIntervalGain.data + btcIntervalGain.data) / 2
-      console.log(cellarIntervalGainPct)
-      console.log((ethIntervalGain.data + btcIntervalGain.data) / 2)
+
       return result
     },
     {

--- a/src/data/hooks/useIntervalGainPct.ts
+++ b/src/data/hooks/useIntervalGainPct.ts
@@ -1,20 +1,20 @@
 import { useQuery } from "@tanstack/react-query"
 import { ConfigProps } from "data/types"
 import { useGetSingleCellarValueQuery } from "generated/subgraph"
-import { getPreviousWeek, getToday } from "utils/calculateTime"
+import { getPreviousDay, getPreviousWeek } from "utils/calculateTime"
 import { getGainPct } from "utils/getGainPct"
 import { useBtcIntervalGain } from "./useBtcIntervalGain"
 import { useEthIntervalGain } from "./useEthIntervalGain"
 
 export const useIntervalGainPct = (config: ConfigProps) => {
   // Shift back coingecko by 1 day is intentional
-  const ethIntervalGain = useEthIntervalGain(6)
-  const btcIntervalGain = useBtcIntervalGain(6)
+  const ethIntervalGain = useEthIntervalGain(7)
+  const btcIntervalGain = useBtcIntervalGain(7)
 
   const [todayData] = useGetSingleCellarValueQuery({
     variables: {
       cellarAddress: config.id,
-      epoch: getToday(),
+      epoch: getPreviousDay(),
     },
   })
 
@@ -64,10 +64,13 @@ export const useIntervalGainPct = (config: ConfigProps) => {
         Number(previousWeekDatas[0].shareValue)
       )
 
+      console.log(new Date(previousWeekDatas[0].date * 1000))
+      console.log(new Date(todayDatas[0].date * 1000))
       const result =
         cellarIntervalGainPct -
         (ethIntervalGain.data + btcIntervalGain.data) / 2
-
+      console.log(cellarIntervalGainPct)
+      console.log((ethIntervalGain.data + btcIntervalGain.data) / 2)
       return result
     },
     {

--- a/src/utils/calculateTime.ts
+++ b/src/utils/calculateTime.ts
@@ -24,6 +24,15 @@ export const getPreviousWeek = (): number => {
   return secondsSinceEpoch
 }
 
+export const getPreviousDay = (): number => {
+  const now = new Date()
+  const lastWeekInSeconds = 24 * 60 * 60 * 2
+  now.setSeconds(now.getSeconds() - lastWeekInSeconds)
+  const secondsSinceEpoch = Math.round(now.getTime() / 1000)
+
+  return secondsSinceEpoch
+}
+
 export const getPreviousMonth = (): number => {
   const dayInMs = 24 * 60 * 60 * 1000
   const now = new Date()


### PR DESCRIPTION
Fixes weekly change calculations

## Description

Fixes different dates on comparing 1 week changes and add a prevention mutating latest hour on the last day 

## Changes
- [x] [fix: weekly change calculations](https://github.com/strangelove-ventures/sommelier/commit/fefe4ba67f1a2ecbaca2cf58579c59b54a9ff4b1)
- [x] [fix: getWeeklyAsset use 6 day](https://github.com/strangelove-ventures/sommelier/commit/c5c45f0464a9eb62d040570b9a310862c5c93991)
- [x] [chore: add comments on coingecko today data](https://github.com/strangelove-ventures/sommelier/pull/660/commits/42bd4522cef497933ec4b2354cea6b7eb67dcccc)
- [x] [fix: token price change not same with chart](https://github.com/strangelove-ventures/sommelier/pull/660/commits/e08aaf85c97a6eb5db813404f18c4726e91e0f75)
- [x] [refactor: simplify code](https://github.com/strangelove-ventures/sommelier/pull/660/commits/8bd2165e34aa1290b10c658a74d4d77e44c91790)
- [x] [chore: remove non null assertion](https://github.com/strangelove-ventures/sommelier/pull/660/commits/37555aa0b8e25060c72cbb51ebd7e1e26cae7a92)
- [x] [fix: setDataWeekly token price change](https://github.com/strangelove-ventures/sommelier/pull/660/commits/4f39f5c19ad575e0912663684a29dbe8627309c4)
- [x] [feat: add prevention response not having latest hour](https://github.com/strangelove-ventures/sommelier/pull/660/commits/69e267e57fd7ccd67049bea6f6e2a311b774a2eb)
