### PR TITLE
Send cellar id and name to deposit events, track wallet address

### DIFF
--- a/src/components/_buttons/ConnectButton/index.tsx
+++ b/src/components/_buttons/ConnectButton/index.tsx
@@ -38,10 +38,16 @@ const ConnectButton = ({
         message: error.message,
       })
     },
-    onSuccess: () => {
-      analytics.track("wallet.connect-succeeded", {
-        account: address,
-      })
+    onSuccess: (data) => {
+      const { account } = data
+
+      if (account && account.length) {
+        analytics.track("wallet.connect-succeeded", {
+          account,
+        })
+
+        analytics.identify(account)
+      }
     },
   })
 

--- a/src/components/_modals/DepositModal/SommelierTab.tsx
+++ b/src/components/_modals/DepositModal/SommelierTab.tsx
@@ -56,9 +56,17 @@ type DepositModalProps = Pick<ModalProps, "isOpen" | "onClose">
 
 export const SommelierTab: VFC<DepositModalProps> = (props) => {
   const id = useRouter().query.id as string
-  const cellarConfig = cellarDataMap[id].config
-  const cellarName = cellarDataMap[id].name
-  const depositTokens = cellarDataMap[id].depositTokens.list
+  const cellarData = cellarDataMap[id]
+  const cellarConfig = cellarData.config
+  const cellarName = cellarData.name
+  const cellarAddress = cellarConfig.id
+  const depositTokens = cellarData.depositTokens.list
+
+  // Base Analytics data to differentiate between cellars
+  const baseAnalytics = {
+    cellarName,
+    cellarAddress,
+  }
 
   const { data: signer } = useSigner()
   const { address } = useAccount()
@@ -85,6 +93,7 @@ export const SommelierTab: VFC<DepositModalProps> = (props) => {
   function trackedSetSelectedToken(value: TokenType | null) {
     if (value && value !== selectedToken) {
       analytics.track("deposit.stable-selected", {
+        ...baseAnalytics,
         stable: value.symbol,
       })
     }
@@ -134,6 +143,7 @@ export const SommelierTab: VFC<DepositModalProps> = (props) => {
 
     if (!erc20Contract) return
     analytics.track("deposit.started", {
+      ...baseAnalytics,
       stable: tokenSymbol,
       value: depositAmount,
     })
@@ -161,6 +171,7 @@ export const SommelierTab: VFC<DepositModalProps> = (props) => {
 
     if (needsApproval) {
       analytics.track("deposit.approval-required", {
+        ...baseAnalytics,
         stable: tokenSymbol,
         value: depositAmount,
       })
@@ -184,6 +195,7 @@ export const SommelierTab: VFC<DepositModalProps> = (props) => {
         const result = await waitForApproval
         if (result?.data?.transactionHash) {
           analytics.track("deposit.approval-granted", {
+            ...baseAnalytics,
             stable: tokenSymbol,
             value: depositAmount,
           })
@@ -196,6 +208,7 @@ export const SommelierTab: VFC<DepositModalProps> = (props) => {
           })
         } else if (result?.error) {
           analytics.track("deposit.approval-failed", {
+            ...baseAnalytics,
             stable: tokenSymbol,
             value: depositAmount,
           })
@@ -209,6 +222,7 @@ export const SommelierTab: VFC<DepositModalProps> = (props) => {
         }
       } catch (e) {
         analytics.track("deposit.approval-cancelled", {
+          ...baseAnalytics,
           stable: tokenSymbol,
           value: depositAmount,
         })
@@ -262,6 +276,7 @@ export const SommelierTab: VFC<DepositModalProps> = (props) => {
       const depositResult = await waitForDeposit
       if (depositResult?.data?.transactionHash) {
         analytics.track("deposit.succeeded", {
+          ...baseAnalytics,
           stable: tokenSymbol,
           value: depositAmount,
         })
@@ -295,6 +310,7 @@ export const SommelierTab: VFC<DepositModalProps> = (props) => {
 
       if (depositResult?.error) {
         analytics.track("deposit.failed", {
+          ...baseAnalytics,
           stable: tokenSymbol,
           value: depositAmount,
         })

--- a/src/components/_pages/PageHome.tsx
+++ b/src/components/_pages/PageHome.tsx
@@ -15,7 +15,7 @@ import { cellarDataMap } from "data/cellarDataMap"
 import { CellarType } from "data/types"
 import { config } from "utils/config"
 import { analytics } from "utils/analytics"
-import { landingType } from "utils/landingType"
+import { DIRECT, landingType } from "utils/landingType"
 
 interface CellarGridItemsType {
   section: CellarType
@@ -52,10 +52,24 @@ const PageHome: NextPage<HomeProps> = ({ faqData }) => {
               display="flex"
               borderRadius={28}
               onClick={() => {
+                const landingTyp = landingType()
+
                 analytics.track("strategy.selection", {
                   strategyCard: cellarDataMap[cellar].name,
                   landingType: landingType(),
                 })
+
+                if (landingTyp === DIRECT) {
+                  analytics.track("strategy.selection.direct", {
+                    strategyCard: cellarDataMap[cellar].name,
+                    landingType: landingTyp,
+                  })
+                } else {
+                  analytics.track("strategy.selection.indirect", {
+                    strategyCard: cellarDataMap[cellar].name,
+                    landingType: landingTyp,
+                  })
+                }
               }}
             >
               <CellarCard cellarAddress={cellar} as="li" />

--- a/src/utils/landingType.ts
+++ b/src/utils/landingType.ts
@@ -1,4 +1,4 @@
-const DIRECT = "Direct"
+export const DIRECT = "Direct"
 
 export const landingType = () => {
   const referrer = document.referrer

--- a/src/utils/landingType.ts
+++ b/src/utils/landingType.ts
@@ -1,7 +1,9 @@
+const DIRECT = "Direct"
+
 export const landingType = () => {
   const referrer = document.referrer
   if (referrer === "" || !referrer) {
-    return "Direct"
+    return DIRECT
   }
   return referrer
 }


### PR DESCRIPTION
- Identifies connected users by wallet address
- Sends cellar name and address to deposit events
- Add new events for tracking direct and indirect strategy card selection as requested by Owldon