### PR TITLE
feat: change manage portofolio to view details

### DIFF
--- a/src/components/HeroStrategy/hero-right.tsx
+++ b/src/components/HeroStrategy/hero-right.tsx
@@ -92,7 +92,7 @@ export const HeroStrategyRight: VFC<HeroStrategyRightProps> = ({
             style={{ textDecoration: "none" }}
           >
             <SecondaryButton w="full" h="50px">
-              Manage Portfolio
+              View Details
             </SecondaryButton>
           </Link>
           <HStack


### PR DESCRIPTION
Fixes #680 

## Description

Change manage portofolio to view details

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/43783037/204155512-4162d3d6-6dd6-4b47-b0d6-11c3376d89ea.png)
