### PR TITLE
fix: bonding amount > 1k

### DIFF
--- a/src/components/_cards/BondingTableCard.tsx
+++ b/src/components/_cards/BondingTableCard.tsx
@@ -240,7 +240,6 @@ const BondingTableCard: VFC<TableProps> = (props) => {
                 const { amount, lock, rewards, unbondTimestamp } =
                   data
                 const lockMap = bondingPeriodOptions(cellarConfig)
-
                 if (amount?.toString() === "0") return null
                 return (
                   <Tr
@@ -261,7 +260,7 @@ const BondingTableCard: VFC<TableProps> = (props) => {
                     }}
                   >
                     <Td>#{formatTrancheNumber(i + 1)}</Td>
-                    <Td>{toEther(amount.toString())}</Td>
+                    <Td>{toEther(amount.toFixed())}</Td>
                     <Td>{lockMap[lock].title}</Td>
                     <Td>
                       {claimAllRewards


### PR DESCRIPTION
Fixes #718 

## Description

`ethers.BigNumberish` doesn't pickup `toString` ex: `1e+21` need to Change it to `toFixed`

## Changes

- [x] [fix: bonding amount > 1k](https://github.com/strangelove-ventures/sommelier/commit/45170d51cb889033542d67e2a653c6610c9c7b12)
