### PR TITLE
feat: add info block in strategy details page

### DIFF
--- a/src/components/_cards/PortfolioCard/index.tsx
+++ b/src/components/_cards/PortfolioCard/index.tsx
@@ -38,9 +38,8 @@ import {
 import { BondButton } from "components/_buttons/BondButton"
 import { useApy } from "data/hooks/useApy"
 import { InnerCard } from "../InnerCard"
-import { formatDistanceToNow } from "date-fns"
+import { formatDistanceToNow, isFuture } from "date-fns"
 import { CoinImage } from "../CellarCard/CoinImage"
-import { isComingSoon } from "utils/isComingSoon"
 
 export const PortfolioCard: VFC<BoxProps> = (props) => {
   const isMounted = useIsMounted()
@@ -70,7 +69,6 @@ export const PortfolioCard: VFC<BoxProps> = (props) => {
 
   const { data: netValue } = useNetValue(cellarConfig)
   const { data: activeAsset } = useActiveAsset(cellarConfig)
-  const isEarn = isComingSoon(cellarStaking.endDate)
 
   return (
     <TransparentCard p={8} {...props}>
@@ -220,7 +218,7 @@ export const PortfolioCard: VFC<BoxProps> = (props) => {
           isConnected &&
           userStakes?.userStakes.length && <BondingTableCard />}
       </VStack>
-      {isEarn && (
+      {cellarStaking && isFuture(cellarStaking?.endDate) && (
         <InnerCard mt="8" px="7" py="7">
           <HStack>
             <CoinImage boxSize="1.6rem" mr="6px" />

--- a/src/components/_cards/PortfolioCard/index.tsx
+++ b/src/components/_cards/PortfolioCard/index.tsx
@@ -1,8 +1,12 @@
 import {
   BoxProps,
+  Heading,
+  HStack,
   Image,
   SimpleGrid,
+  Spacer,
   Stack,
+  Text,
   VStack,
 } from "@chakra-ui/react"
 import { CardStat } from "components/CardStat"
@@ -32,14 +36,25 @@ import {
   lpTokenTooltipContent,
 } from "data/uiConfig"
 import { BondButton } from "components/_buttons/BondButton"
+import { useApy } from "data/hooks/useApy"
+import { InnerCard } from "../InnerCard"
+import { formatDistanceToNow } from "date-fns"
+import { CoinImage } from "../CellarCard/CoinImage"
+import { isComingSoon } from "utils/isComingSoon"
 
 export const PortfolioCard: VFC<BoxProps> = (props) => {
   const isMounted = useIsMounted()
   const { isConnected } = useAccount()
   const id = useRouter().query.id as string
   const cellarConfig = cellarDataMap[id].config
+  const cellarStaking = cellarDataMap[id].staking
   const depositTokens = cellarDataMap[id].depositTokens.list
   const depositTokenConfig = getTokenConfig(depositTokens)
+  const { data: apy, isLoading: apyLoading } = useApy(cellarConfig)
+
+  const potentialStakingApy = apyLoading
+    ? "-"
+    : apy?.potentialStakingApy
 
   const { connectors } = useConnect()
 
@@ -55,12 +70,12 @@ export const PortfolioCard: VFC<BoxProps> = (props) => {
 
   const { data: netValue } = useNetValue(cellarConfig)
   const { data: activeAsset } = useActiveAsset(cellarConfig)
+  const isEarn = isComingSoon(cellarStaking.endDate)
 
   return (
     <TransparentCard p={8} {...props}>
       <VStack align="stretch" spacing={8}>
         <CardStatRow
-          // px={{ md: 10 }}
           spacing={{ sm: 4, md: 8, lg: 14 }}
           align="flex-start"
           justify="flex-start"
@@ -205,6 +220,21 @@ export const PortfolioCard: VFC<BoxProps> = (props) => {
           isConnected &&
           userStakes?.userStakes.length && <BondingTableCard />}
       </VStack>
+      {isEarn && (
+        <InnerCard mt="8" px="7" py="7">
+          <HStack>
+            <CoinImage boxSize="1.6rem" mr="6px" />
+            <Heading size="16px">
+              Earn rewards when you bond {potentialStakingApy} . up to{" "}
+              {cellarStaking.multiplier}
+            </Heading>
+            <Spacer />
+            <Text fontSize="xs">
+              Ends in {formatDistanceToNow(cellarStaking.endDate)}
+            </Text>
+          </HStack>
+        </InnerCard>
+      )}
     </TransparentCard>
   )
 }


### PR DESCRIPTION
Fixes #709 

## Description

add info block in strategy details page


## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/43783037/204890738-2ff2dbd6-1956-4ef0-ad41-c3b156239222.png)
