### PR TITLE
fix: default value deposit assets modal

### DIFF
--- a/src/components/_menus/ModalMenu/Menu.tsx
+++ b/src/components/_menus/ModalMenu/Menu.tsx
@@ -22,6 +22,9 @@ import { useFormContext } from "react-hook-form"
 import { toEther } from "utils/formatCurrency"
 import { ModalMenuProps } from "."
 import { analytics } from "utils/analytics"
+import { useRouter } from "next/router"
+import { cellarDataMap } from "data/cellarDataMap"
+import { depositAssetDefaultValue } from "data/uiConfig"
 
 export interface MenuProps
   extends Omit<ModalMenuProps, "setSelectedToken"> {
@@ -46,6 +49,9 @@ export const Menu: VFC<MenuProps> = ({
     false,
     6
   )}`
+  const id = useRouter().query.id as string
+  const cellarData = cellarDataMap[id]
+  const cellarConfig = cellarData.config
 
   const depositTokenConfig = getTokenConfig(depositTokens) as Token[]
   const setMax = () => {
@@ -116,7 +122,9 @@ export const Menu: VFC<MenuProps> = ({
           w={menuDims?.borderBox.width}
         >
           <MenuOptionGroup
-            defaultValue={activeAsset && depositTokenConfig[0].symbol}
+            defaultValue={
+              activeAsset && depositAssetDefaultValue(cellarConfig)
+            }
             type="radio"
           >
             <Box pt={4} pb={2} pl={10}>

--- a/src/data/uiConfig.ts
+++ b/src/data/uiConfig.ts
@@ -35,6 +35,13 @@ export const intervalGainTimeline = (config: ConfigProps) => {
   return "weekly"
 }
 
+export const depositAssetDefaultValue = (config: ConfigProps) => {
+  if (config.cellarNameKey === CellarNameKey.AAVE) {
+    return "USDT"
+  }
+  return "USDC"
+}
+
 export const isPositionTokenAssets = (config: ConfigProps) => {
   return (
     config.cellarNameKey === CellarNameKey.ETH_BTC_MOM ||


### PR DESCRIPTION
Note: Already try to pass value.symbol in `MenuOptionGroup` default value, but is not working

## Description

default value deposit assets modal

## Changes

List any technical changes.

- [ ] [fix: default value deposit assets modal](https://github.com/strangelove-ventures/sommelier/commit/b7354610e5f56bcf7d3f9a7aebe1c24d4e194d97)

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/43783037/206019169-890416d5-18d4-4b5a-ab8c-d1513e90c43c.png)

![image](https://user-images.githubusercontent.com/43783037/206019302-f6785385-9033-4597-890c-136f85fdc64a.png)
