### PR TITLE
Feat/access restricted when do a transactions

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,16 +1,13 @@
 import { VFC } from "react"
 import { Box, Container, Flex, FlexProps } from "@chakra-ui/react"
-import { useGeo } from "context/geoContext"
 import { BackgroundAssets } from "./BackgroundAssets"
 import { Nav } from "./Nav"
-import { GeoBanner } from "./_banners/GeoBanner"
 import Footer from "./Footer"
 import { useAccount, useNetwork } from "wagmi"
 import { WrongNetworkBanner } from "./_banners/WrongNetworkBanner"
 import { useIsMounted } from "hooks/utils/useIsMounted"
 
 export const Layout: VFC<FlexProps> = ({ children, ...rest }) => {
-  const { isRestricted } = useGeo() || {}
   const { isConnected } = useAccount()
   const { chain } = useNetwork()
   const isMounted = useIsMounted()
@@ -28,7 +25,6 @@ export const Layout: VFC<FlexProps> = ({ children, ...rest }) => {
             maxW="container.lg"
             px={{ base: 0, sm: 4 }}
           >
-            {isRestricted && <GeoBanner />}
             {isMounted && isConnected && chain?.id !== 1 && (
               <WrongNetworkBanner />
             )}

--- a/src/components/_cards/BondingTableCard.tsx
+++ b/src/components/_cards/BondingTableCard.tsx
@@ -30,6 +30,7 @@ import { useStakingEnd } from "data/hooks/useStakingEnd"
 import { formatDistanceToNow, isFuture } from "date-fns"
 import { LighterSkeleton } from "components/_skeleton"
 import { formatDistance } from "utils/formatDistance"
+import { useGeo } from "context/geoContext"
 
 const formatTrancheNumber = (number: number): string => {
   if (number < 10) {
@@ -59,7 +60,12 @@ const BondingTableCard: VFC<TableProps> = (props) => {
 
   const stakingEnd = useStakingEnd(cellarConfig)
 
+  const geo = useGeo()
+
   const handleUnstake = async (id: number) => {
+    if (geo?.isRestrictedAndOpenModal()) {
+      return
+    }
     try {
       setUnstakeLoading((oldState) => {
         const newState = new Set(oldState)
@@ -90,6 +96,9 @@ const BondingTableCard: VFC<TableProps> = (props) => {
   }
 
   const handleUnBond = async (id: number) => {
+    if (geo?.isRestrictedAndOpenModal()) {
+      return
+    }
     try {
       setUnbondLoading((oldState) => {
         const newState = new Set(oldState)

--- a/src/components/_cards/PortfolioCard/Rewards.tsx
+++ b/src/components/_cards/PortfolioCard/Rewards.tsx
@@ -2,6 +2,7 @@ import { SimpleGrid, VStack } from "@chakra-ui/react"
 import { CardStat } from "components/CardStat"
 import { InlineImage } from "components/InlineImage"
 import { BaseButton } from "components/_buttons/BaseButton"
+import { useGeo } from "context/geoContext"
 import { useCreateContracts } from "data/hooks/useCreateContracts"
 import { useUserStakes } from "data/hooks/useUserStakes"
 import { ConfigProps } from "data/types"
@@ -28,7 +29,11 @@ export const Rewards = ({
 
   const { doHandleTransaction } = useHandleTransaction()
 
+  const geo = useGeo()
   const handleClaimAll = async () => {
+    if (geo?.isRestrictedAndOpenModal()) {
+      return
+    }
     analytics.track("rewards.claim-started")
     const tx = await stakerSigner?.claimAll()
     await doHandleTransaction({

--- a/src/components/_forms/BondForm/index.tsx
+++ b/src/components/_forms/BondForm/index.tsx
@@ -30,6 +30,7 @@ import { useUserBalances } from "data/hooks/useUserBalances"
 import { useUserStakes } from "data/hooks/useUserStakes"
 import { bondingPeriodOptions } from "data/uiConfig"
 import { estimateGasLimit } from "utils/estimateGasLimit"
+import { useGeo } from "context/geoContext"
 
 interface FormValues {
   depositAmount: number
@@ -80,7 +81,12 @@ export const BondForm: VFC<BondFormProps> = ({ onClose }) => {
       parseFloat(toEther(lpTokenData?.formatted, 18, false) || "")
     )
 
+  const geo = useGeo()
+
   const onSubmit = async (data: FormValues) => {
+    if (geo?.isRestrictedAndOpenModal()) {
+      return
+    }
     if (!stakerSigner) {
       return addToast({
         heading: "No wallet connected",

--- a/src/components/_forms/UnstakeForm.tsx
+++ b/src/components/_forms/UnstakeForm.tsx
@@ -24,6 +24,7 @@ import { cellarDataMap } from "data/cellarDataMap"
 import { useCreateContracts } from "data/hooks/useCreateContracts"
 import { useUserBalances } from "data/hooks/useUserBalances"
 import { useUserStakes } from "data/hooks/useUserStakes"
+import { useGeo } from "context/geoContext"
 interface FormValues {
   withdrawAmount: number
 }
@@ -81,7 +82,12 @@ export const UnstakeForm: VFC<UnstakeFormProps> = ({ onClose }) => {
     }
   }, [watchWithdrawAmount, address])
 
+  const geo = useGeo()
+
   const onSubmit = async ({ withdrawAmount }: FormValues) => {
+    if (geo?.isRestrictedAndOpenModal()) {
+      return
+    }
     if (withdrawAmount <= 0) return
 
     if (!address) {

--- a/src/components/_forms/WithdrawForm.tsx
+++ b/src/components/_forms/WithdrawForm.tsx
@@ -26,6 +26,7 @@ import { useCreateContracts } from "data/hooks/useCreateContracts"
 import { useUserBalances } from "data/hooks/useUserBalances"
 import { estimateGasLimit } from "utils/estimateGasLimit"
 import { useNetValue } from "data/hooks/useNetValue"
+import { useGeo } from "context/geoContext"
 interface FormValues {
   withdrawAmount: number
 }
@@ -85,7 +86,11 @@ export const WithdrawForm: VFC<WithdrawFormProps> = ({ onClose }) => {
     }
   }, [watchWithdrawAmount, address])
 
+  const geo = useGeo()
   const onSubmit = async ({ withdrawAmount }: FormValues) => {
+    if (geo?.isRestrictedAndOpenModal()) {
+      return
+    }
     if (withdrawAmount <= 0) return
 
     if (!address) {

--- a/src/components/_modals/DepositModal/SommelierTab.tsx
+++ b/src/components/_modals/DepositModal/SommelierTab.tsx
@@ -52,6 +52,7 @@ import { useActiveAsset } from "data/hooks/useActiveAsset"
 import { useDepositAndSwap } from "data/hooks/useDepositAndSwap"
 import { isActiveTokenStrategyEnabled } from "data/uiConfig"
 import { useNetValue } from "data/hooks/useNetValue"
+import { useGeo } from "context/geoContext"
 
 type DepositModalProps = Pick<ModalProps, "isOpen" | "onClose">
 
@@ -137,7 +138,11 @@ export const SommelierTab: VFC<DepositModalProps> = (props) => {
     selectedToken?.address?.toLowerCase() ===
     activeAsset?.address?.toLowerCase()
 
+  const geo = useGeo()
   const onSubmit = async (data: any, e: any) => {
+    if (geo?.isRestrictedAndOpenModal()) {
+      return
+    }
     const tokenSymbol = data?.selectedToken?.symbol
     const depositAmount = data?.depositAmount
 

--- a/src/components/_modals/RestrictedModal.tsx
+++ b/src/components/_modals/RestrictedModal.tsx
@@ -1,0 +1,32 @@
+import { Stack, Text, useDisclosure } from "@chakra-ui/react"
+import { BaseButton } from "components/_buttons/BaseButton"
+import { BaseModal } from "./BaseModal"
+
+export const RestrictedModal = (
+  props: ReturnType<typeof useDisclosure>
+) => {
+  return (
+    <BaseModal heading="Access Restricted" {...props}>
+      <Stack spacing={6}>
+        <Text>
+          You may be attempting to use Sommelier in a restricted
+          territory or while using a VPN which shows your location as
+          a restricted territory (including the United States).
+        </Text>
+        <Text>
+          Make sure your VPN settings are updated to your real
+          location, and you are not using Safari Private browsing,
+          then try again. To learn more, view our terms of service.
+        </Text>
+        <BaseButton
+          size="lg"
+          height="70px"
+          fontSize="21px"
+          onClick={props.onClose}
+        >
+          Got it
+        </BaseButton>
+      </Stack>
+    </BaseModal>
+  )
+}

--- a/src/context/geoContext.tsx
+++ b/src/context/geoContext.tsx
@@ -8,6 +8,7 @@ import {
   useEffect,
   useState,
 } from "react"
+import { analytics } from "utils/analytics"
 
 const BASE_URL =
   process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"
@@ -47,6 +48,7 @@ export const GeoProvider: FC<ReactNode> = ({ children }) => {
   const isRestrictedAndOpenModal = () => {
     if (ctx.isRestricted) {
       restrictedModal.onOpen()
+      analytics.track("user.modal-access-restricted-opened")
       return true
     }
     return false

--- a/src/context/geoContext.tsx
+++ b/src/context/geoContext.tsx
@@ -1,3 +1,5 @@
+import { useDisclosure } from "@chakra-ui/react"
+import { RestrictedModal } from "components/_modals/RestrictedModal"
 import {
   createContext,
   FC,
@@ -10,18 +12,25 @@ import {
 const BASE_URL =
   process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"
 
-type CheckIPContext =
-  | {
-      country: string
-      region: string
-      isRestricted: boolean
-    }
-  | undefined
+type CheckIPState = {
+  country: string | null
+  region: string | null
+  isRestricted: boolean
+}
+
+interface CheckIPContext extends CheckIPState {
+  isRestrictedAndOpenModal: () => boolean
+}
 
 const geoContext = createContext<CheckIPContext | null>(null)
 
 export const GeoProvider: FC<ReactNode> = ({ children }) => {
-  const [ctx, setCtx] = useState<CheckIPContext>()
+  const [ctx, setCtx] = useState<CheckIPState>({
+    country: null,
+    region: null,
+    isRestricted: false,
+  })
+  const restrictedModal = useDisclosure()
 
   useEffect(() => {
     const getRegionData = async () => {
@@ -35,8 +44,24 @@ export const GeoProvider: FC<ReactNode> = ({ children }) => {
     getRegionData()
   }, [])
 
+  const isRestrictedAndOpenModal = () => {
+    if (ctx.isRestricted) {
+      restrictedModal.onOpen()
+      return true
+    }
+    return false
+  }
+
   return (
-    <geoContext.Provider value={ctx}>{children}</geoContext.Provider>
+    <geoContext.Provider
+      value={{
+        ...ctx,
+        isRestrictedAndOpenModal,
+      }}
+    >
+      {children}
+      <RestrictedModal {...restrictedModal} />
+    </geoContext.Provider>
   )
 }
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -19,8 +19,8 @@ const App = ({ Component, pageProps }: AppProps) => {
       <PlausibleProvider
         domain={process.env.NEXT_PUBLIC_PLAUSIBLE_URL!}
       >
-        <GeoProvider>
-          <ChakraProvider theme={theme}>
+        <ChakraProvider theme={theme}>
+          <GeoProvider>
             <GlobalFonts />
             <DialogProvider>
               <WagmiProvider>
@@ -30,8 +30,8 @@ const App = ({ Component, pageProps }: AppProps) => {
                 <AlertDialog />
               </WagmiProvider>
             </DialogProvider>
-          </ChakraProvider>
-        </GeoProvider>
+          </GeoProvider>
+        </ChakraProvider>
       </PlausibleProvider>
     </GraphQLProvider>
   )


### PR DESCRIPTION
Closes  #757 

## Description

Remove Access restricted banner, change it to when doing a transactions if the user got access restricted open a access restricted modal and reject the transactions

## Changes

- [x] [feat: RestrictedModal component](https://github.com/strangelove-ventures/sommelier/commit/7b9e7374f3e37a7bb061a33532fb92ab742845b6)
- [x] [refactor: adjust geo context and provider](https://github.com/strangelove-ventures/sommelier/commit/4c785816753ab73b973223c324e21012e125ebe3)
- [x] [feat: remove geo banner](https://github.com/strangelove-ventures/sommelier/commit/5cb1a1b5ab50c516c42798a509eb7f68f43130f7)
- [x] [feat: add analytics when opened](https://github.com/strangelove-ventures/sommelier/commit/a7b6e0c659a678a5924d556a2f1a66938b0d9932)
- [x] [feat: reject transaction if got restricted](https://github.com/strangelove-ventures/sommelier/commit/82075030b8f235ae5725b3a3a6d577fd5bfc244d)

## Screenshots :

https://user-images.githubusercontent.com/39829726/206576679-98de3462-9eaf-4783-87c5-6e63d92277da.mp4



## Testing Steps

As a reviewer, what steps should I take to verify this is working correctly?

- open preview site with vpn and choose us state or (dev mode)change your env `IP_COUNTRY=US` 
- connect a wallet
- go to one of the strategies
- do a transaction such as buy, sell, bond, unbod, unstake, claim
- expected behavior will be showing a modal that user got access restricted and the transactions not continue
