### PR TITLE
fix: rework gtm to trigger with window.dataLayer.push

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -2,10 +2,11 @@
  * Full type definitions for all injected keplr related objects
  * @see https://github.com/chainapsis/keplr-wallet/tree/master/packages/types
  */
-type KeplrWindow = import('@keplr-wallet/types/src/window').Window
+type KeplrWindow = import("@keplr-wallet/types/src/window").Window
 
 declare interface Window extends KeplrWindow {
   // Entrypoint for overriding `window` types
   // Note: window.ethereum is already declared via `wagmi`
   //
+  dataLayer: any
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,17 +1,14 @@
 import { ColorModeScript } from "@chakra-ui/react"
 import { NextPage } from "next"
 import { Head, Html, Main, NextScript } from "next/document"
-// eslint-disable-next-line @next/next/no-script-in-document
-import Script from "next/script"
 import { config } from "theme/index"
 
 const CustomDocument: NextPage = () => {
   return (
     <Html lang="en">
       <Head>
-        <Script
-          id="google-tag-manager"
-          strategy="afterInteractive"
+        {/* eslint-disable-next-line @next/next/next-script-for-ga */}
+        <script
           dangerouslySetInnerHTML={{
             __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -20,18 +17,18 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 })(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_GTM_ID}')
 `,
           }}
-        ></Script>
+        />
       </Head>
 
       <body>
+        <ColorModeScript initialColorMode={config.initialColorMode} />
+        <Main />
+        <NextScript />
         <noscript
           dangerouslySetInnerHTML={{
             __html: `<iframe src="https://www.googletagmanager.com/ns.html?id=${process.env.NEXT_PUBLIC_GTM_ID}" height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
           }}
         ></noscript>
-        <ColorModeScript initialColorMode={config.initialColorMode} />
-        <Main />
-        <NextScript />
       </body>
     </Html>
   )

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,5 +1,4 @@
 import Analytics from "analytics"
-import googleTagManager from "@analytics/google-tag-manager"
 import mixpanel from "@analytics/mixpanel"
 
 const isBrowser = typeof window !== "undefined"
@@ -25,20 +24,10 @@ const appName =
 
 // Google Tag Manager
 const gtmId = process.env.NEXT_PUBLIC_GTM_ID
-const gtmAuth = process.env.NEXT_PUBLIC_GTM_AUTH
-const gtmPreview = process.env.NEXT_PUBLIC_GTM_PREVIEW
+const isSendToGTM =
+  isBrowser && gtmId && gtmId !== null && gtmId.length > 0
 
 const plugins = []
-
-if (isBrowser && gtmId != null && gtmId.length > 0) {
-  const config = {
-    containerId: gtmId,
-    auth: gtmAuth,
-    preview: gtmPreview,
-  }
-
-  plugins.push(googleTagManager(config))
-}
 
 const mixpanelToken = process.env.NEXT_PUBLIC_MIXPANEL_TOKEN
 if (isBrowser && mixpanelToken && mixpanelToken.length > 0) {
@@ -69,6 +58,9 @@ export class AnalyticsWrapper {
 
   track(eventName: string, payload?: Record<string, unknown>) {
     this.enabled && this.client.track(eventName, payload)
+    this.enabled &&
+      isSendToGTM &&
+      window.dataLayer?.push({ event: eventName, ...payload })
   }
 
   // strips invalid characters


### PR DESCRIPTION
Fixes Analytics event not sending to google tag manager's `window.dataLayer`

## Changes

- [x] [fix: rework gtm to trigger with window.dataLayer.push](https://github.com/strangelove-ventures/sommelier/commit/5202829e56cdd1472288ee68a88da843e7f0fe56)

## Screenshots (if appropriate):
![CleanShot 2023-01-06 at 00 31 59](https://user-images.githubusercontent.com/39829726/210843802-23ae4921-7fd2-4270-a2db-b02e0c8c2f50.png)


## Testing Steps

1. open https://sommelier-drmnapxik-sommelierfinance.vercel.app/
2. click one of the cards
3. open console
4. check `dataLayer` object it should have `strategy.selection` event