### PR TITLE
feat: chart quick update

### DIFF
--- a/src/components/_charts/ApyChart.tsx
+++ b/src/components/_charts/ApyChart.tsx
@@ -111,8 +111,27 @@ export const ApyChart: VFC<TokenPriceChartProps> = ({
     if (timeline === "1D") {
       return {
         axisBottom: {
-          format: "%d %H:%M",
+          format: "%d.%b %H:%M",
           tickValues: isLarger768 ? "every 3 hours" : "every 6 hours",
+        },
+      }
+    }
+    if (timeline === "1W" || timeline === "1M") {
+      // show format in day.month
+      return {
+        axisBottom: {
+          format: "%d.%b",
+          tickValues:
+            timeline === "1W" ? "every 1 day" : "every 2 days",
+        },
+      }
+    }
+    if (timeline === "1Y" || timeline === "ALL") {
+      // show format in month.year
+      return {
+        axisBottom: {
+          format: "%b.%y",
+          tickValues: "every 1 month",
         },
       }
     }
@@ -150,6 +169,37 @@ export const ApyChart: VFC<TokenPriceChartProps> = ({
         nice: true,
       }}
       axisLeft={{
+        renderTick: (tick) => {
+          return (
+            <g
+              transform={`translate(${tick.x + 3},${tick.y})`}
+              style={{ opacity: 1 }}
+            >
+              <line
+                x1="0"
+                x2="-3"
+                y1="0"
+                y2="0"
+                style={{
+                  stroke: "rgb(237, 235, 245)",
+                  strokeWidth: 1,
+                }}
+              />
+              <text
+                transform="translate(-4, 0)"
+                textAnchor="end"
+                dominantBaseline="central"
+                style={{
+                  fontFamily: "sans-serif",
+                  fontSize: 9,
+                  fill: "rgb(237, 235, 245)",
+                }}
+              >
+                {tick.value} %
+              </text>
+            </g>
+          )
+        },
         tickSize: 5,
         tickPadding: 5,
         tickRotation: 0,

--- a/src/components/_charts/EthBtcChart.tsx
+++ b/src/components/_charts/EthBtcChart.tsx
@@ -127,8 +127,27 @@ export const EthBtcChart: VFC<EthBtcChartProps> = ({
     if (timeline === "1D") {
       return {
         axisBottom: {
-          format: "%d %H:%M",
+          format: "%d.%b %H:%M",
           tickValues: isLarger768 ? "every 3 hours" : "every 6 hours",
+        },
+      }
+    }
+    if (timeline === "1W" || timeline === "1M") {
+      // show format in day.month
+      return {
+        axisBottom: {
+          format: "%d.%b",
+          tickValues:
+            timeline === "1W" ? "every 1 day" : "every 2 days",
+        },
+      }
+    }
+    if (timeline === "1Y" || timeline === "ALL") {
+      // show format in month.year
+      return {
+        axisBottom: {
+          format: "%b.%y",
+          tickValues: "every 1 month",
         },
       }
     }
@@ -167,6 +186,37 @@ export const EthBtcChart: VFC<EthBtcChartProps> = ({
         min: "auto",
       }}
       axisLeft={{
+        renderTick: (tick) => {
+          return (
+            <g
+              transform={`translate(${tick.x + 3},${tick.y})`}
+              style={{ opacity: 1 }}
+            >
+              <line
+                x1="0"
+                x2="-3"
+                y1="0"
+                y2="0"
+                style={{
+                  stroke: "rgb(237, 235, 245)",
+                  strokeWidth: 1,
+                }}
+              />
+              <text
+                transform="translate(-4, 0)"
+                textAnchor="end"
+                dominantBaseline="central"
+                style={{
+                  fontFamily: "sans-serif",
+                  fontSize: 9,
+                  fill: "rgb(237, 235, 245)",
+                }}
+              >
+                {tick.value} %
+              </text>
+            </g>
+          )
+        },
         tickSize: 5,
         tickPadding: 5,
         tickRotation: 0,

--- a/src/components/_charts/TokenPriceChart.tsx
+++ b/src/components/_charts/TokenPriceChart.tsx
@@ -120,6 +120,7 @@ export const TokenPriceChart: VFC<TokenPriceChartProps> = ({
   }
 
   const hourlyAxisBottom = useMemo<any>(() => {
+    console.log("timeline", timeline)
     if (timeline === "1D") {
       return {
         axisBottom: {
@@ -138,7 +139,11 @@ export const TokenPriceChart: VFC<TokenPriceChartProps> = ({
         },
       }
     }
-    if (timeline === "1Y" || timeline === "ALL") {
+    if (
+      timeline === "1Y" ||
+      timeline === "ALL" ||
+      timeline === "All"
+    ) {
       // show format in month.year
       return {
         axisBottom: {

--- a/src/components/_charts/TokenPriceChart.tsx
+++ b/src/components/_charts/TokenPriceChart.tsx
@@ -123,8 +123,27 @@ export const TokenPriceChart: VFC<TokenPriceChartProps> = ({
     if (timeline === "1D") {
       return {
         axisBottom: {
-          format: "%d %H:%M",
+          format: "%d.%b %H:%M",
           tickValues: isLarger768 ? "every 3 hours" : "every 6 hours",
+        },
+      }
+    }
+    if (timeline === "1W" || timeline === "1M") {
+      // show format in day.month
+      return {
+        axisBottom: {
+          format: "%d.%b",
+          tickValues:
+            timeline === "1W" ? "every 1 day" : "every 2 days",
+        },
+      }
+    }
+    if (timeline === "1Y" || timeline === "ALL") {
+      // show format in month.year
+      return {
+        axisBottom: {
+          format: "%b.%y",
+          tickValues: "every 1 month",
         },
       }
     }
@@ -163,10 +182,39 @@ export const TokenPriceChart: VFC<TokenPriceChartProps> = ({
         min: "auto",
       }}
       axisLeft={{
-        tickSize: 5,
-        tickPadding: 5,
         tickRotation: 0,
         legendPosition: "middle",
+        renderTick: (tick) => {
+          return (
+            <g
+              transform={`translate(${tick.x + 3},${tick.y})`}
+              style={{ opacity: 1 }}
+            >
+              <line
+                x1="0"
+                x2="-3"
+                y1="0"
+                y2="0"
+                style={{
+                  stroke: "rgb(237, 235, 245)",
+                  strokeWidth: 1,
+                }}
+              />
+              <text
+                transform="translate(-4, 0)"
+                textAnchor="end"
+                dominantBaseline="central"
+                style={{
+                  fontFamily: "sans-serif",
+                  fontSize: 9,
+                  fill: "rgb(237, 235, 245)",
+                }}
+              >
+                {tick.value} %
+              </text>
+            </g>
+          )
+        },
       }}
     />
   )

--- a/src/components/_charts/UsdcChart.tsx
+++ b/src/components/_charts/UsdcChart.tsx
@@ -126,8 +126,27 @@ export const UsdcChart: VFC<UsdcChartProps> = ({
     if (timeline === "1D") {
       return {
         axisBottom: {
-          format: "%d %H:%M",
+          format: "%d.%b %H:%M",
           tickValues: isLarger768 ? "every 3 hours" : "every 6 hours",
+        },
+      }
+    }
+    if (timeline === "1W" || timeline === "1M") {
+      // show format in day.month
+      return {
+        axisBottom: {
+          format: "%d.%b",
+          tickValues:
+            timeline === "1W" ? "every 1 day" : "every 2 days",
+        },
+      }
+    }
+    if (timeline === "1Y" || timeline === "ALL") {
+      // show format in month.year
+      return {
+        axisBottom: {
+          format: "%b.%y",
+          tickValues: "every 1 month",
         },
       }
     }
@@ -166,6 +185,37 @@ export const UsdcChart: VFC<UsdcChartProps> = ({
         min: "auto",
       }}
       axisLeft={{
+        renderTick: (tick) => {
+          return (
+            <g
+              transform={`translate(${tick.x + 3},${tick.y})`}
+              style={{ opacity: 1 }}
+            >
+              <line
+                x1="0"
+                x2="-3"
+                y1="0"
+                y2="0"
+                style={{
+                  stroke: "rgb(237, 235, 245)",
+                  strokeWidth: 1,
+                }}
+              />
+              <text
+                transform="translate(-4, 0)"
+                textAnchor="end"
+                dominantBaseline="central"
+                style={{
+                  fontFamily: "sans-serif",
+                  fontSize: 9,
+                  fill: "rgb(237, 235, 245)",
+                }}
+              >
+                {tick.value} %
+              </text>
+            </g>
+          )
+        },
         tickSize: 5,
         tickPadding: 5,
         tickRotation: 0,


### PR DESCRIPTION
Fixes #998 

## Description

chart quick update
## Changes

List any technical changes.

- [X] Add % on the y-axis for all strategies charts
- [X] 1D view date
- [X] 1W view date
- [X] 1M view date
- [X] All view date 
- [X] Minus sign missing bug

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1397612/236862018-90184a25-a671-4818-914a-9553131dc805.png)
![image](https://user-images.githubusercontent.com/1397612/236862038-a12390e8-8f06-4486-a546-78459f385bb5.png)
![image](https://user-images.githubusercontent.com/1397612/236862056-9f052817-6320-4f32-97f9-ba4d28f30f1a.png)
![image](https://user-images.githubusercontent.com/1397612/236862474-c02cd632-df5d-4b8e-9b28-06f59d229c01.png)

## Testing Steps

As a reviewer, what steps should I take to verify this is working correctly?

- [X] Open token detail page

## Links

Add links to Figma files, documentation, etc.
