### PR TITLE
fix: old chart reponsive and months view

### DIFF
--- a/src/components/_charts/ApyChart.tsx
+++ b/src/components/_charts/ApyChart.tsx
@@ -141,7 +141,7 @@ export const ApyChart: VFC<TokenPriceChartProps> = ({
         return {
           axisBottom: {
             format: "%d.%b",
-            tickValues: "every 3 days",
+            tickValues: isLarger768 ? "every 3 days" : "every 5 days",
           },
         }
       }
@@ -149,7 +149,9 @@ export const ApyChart: VFC<TokenPriceChartProps> = ({
         return {
           axisBottom: {
             format: "%d.%b",
-            tickValues: "every 5 days",
+            tickValues: isLarger768
+              ? "every 5 days"
+              : "every 10 days",
           },
         }
       }

--- a/src/components/_charts/ApyChart.tsx
+++ b/src/components/_charts/ApyChart.tsx
@@ -122,7 +122,11 @@ export const ApyChart: VFC<TokenPriceChartProps> = ({
         axisBottom: {
           format: "%d.%b",
           tickValues:
-            timeline === "1W" ? "every 1 day" : "every 2 days",
+            timeline === "1W"
+              ? "every 1 day"
+              : isLarger768
+              ? "every 2 days"
+              : "every 5 days",
         },
       }
     }
@@ -131,6 +135,22 @@ export const ApyChart: VFC<TokenPriceChartProps> = ({
       timeline === "ALL" ||
       timeline === "All"
     ) {
+      if (data.series && data.series.length < 30) {
+        return {
+          axisBottom: {
+            format: "%d.%b",
+            tickValues: "every 3 days",
+          },
+        }
+      }
+      if (data.series && data.series.length < 120) {
+        return {
+          axisBottom: {
+            format: "%d.%b",
+            tickValues: "every 5 days",
+          },
+        }
+      }
       // show format in month.year
       return {
         axisBottom: {
@@ -139,12 +159,44 @@ export const ApyChart: VFC<TokenPriceChartProps> = ({
         },
       }
     }
-  }, [isLarger768, timeline])
+  }, [isLarger768, timeline, data])
 
   return (
     <LineChart
       {...data.chartProps}
-      {...hourlyAxisBottom}
+      axisBottom={{
+        renderTick: isLarger768
+          ? undefined
+          : (tick) => {
+              const day = tick.value.getDate()
+              const month = tick.value.toLocaleString("default", {
+                month: "short",
+              })
+
+              return (
+                <g transform={`translate(${tick.x},${tick.y + 20})`}>
+                  <text
+                    x={0}
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                    style={{
+                      fill: "white",
+                      fontSize: 12,
+                      fontWeight: 600,
+                    }}
+                  >
+                    <tspan x="0" dy="0">
+                      {day}
+                    </tspan>
+                    <tspan x="0" dy="15">
+                      {month}
+                    </tspan>
+                  </text>
+                </g>
+              )
+            },
+        ...hourlyAxisBottom.axisBottom,
+      }}
       data={data.series || []}
       colors={lineColors}
       animate={false}

--- a/src/components/_charts/ApyChart.tsx
+++ b/src/components/_charts/ApyChart.tsx
@@ -123,7 +123,9 @@ export const ApyChart: VFC<TokenPriceChartProps> = ({
           format: "%d.%b",
           tickValues:
             timeline === "1W"
-              ? "every 1 day"
+              ? isLarger768
+                ? "every 1 day"
+                : "every 2 days"
               : isLarger768
               ? "every 2 days"
               : "every 5 days",
@@ -135,7 +137,7 @@ export const ApyChart: VFC<TokenPriceChartProps> = ({
       timeline === "ALL" ||
       timeline === "All"
     ) {
-      if (data.series && data.series.length < 30) {
+      if (data.series && data.series[0].data.length < 30) {
         return {
           axisBottom: {
             format: "%d.%b",
@@ -143,7 +145,7 @@ export const ApyChart: VFC<TokenPriceChartProps> = ({
           },
         }
       }
-      if (data.series && data.series.length < 120) {
+      if (data.series && data.series[0].data.length < 60) {
         return {
           axisBottom: {
             format: "%d.%b",
@@ -164,39 +166,7 @@ export const ApyChart: VFC<TokenPriceChartProps> = ({
   return (
     <LineChart
       {...data.chartProps}
-      axisBottom={{
-        renderTick: isLarger768
-          ? undefined
-          : (tick) => {
-              const day = tick.value.getDate()
-              const month = tick.value.toLocaleString("default", {
-                month: "short",
-              })
-
-              return (
-                <g transform={`translate(${tick.x},${tick.y + 20})`}>
-                  <text
-                    x={0}
-                    textAnchor="middle"
-                    dominantBaseline="middle"
-                    style={{
-                      fill: "white",
-                      fontSize: 12,
-                      fontWeight: 600,
-                    }}
-                  >
-                    <tspan x="0" dy="0">
-                      {day}
-                    </tspan>
-                    <tspan x="0" dy="15">
-                      {month}
-                    </tspan>
-                  </text>
-                </g>
-              )
-            },
-        ...hourlyAxisBottom.axisBottom,
-      }}
+      {...hourlyAxisBottom}
       data={data.series || []}
       colors={lineColors}
       animate={false}

--- a/src/components/_charts/EthBtcChart.tsx
+++ b/src/components/_charts/EthBtcChart.tsx
@@ -151,6 +151,22 @@ export const EthBtcChart: VFC<EthBtcChartProps> = ({
       timeline === "ALL" ||
       timeline === "All"
     ) {
+      if (data.series && data.series.length < 30) {
+        return {
+          axisBottom: {
+            format: "%d.%b",
+            tickValues: "every 3 days",
+          },
+        }
+      }
+      if (data.series && data.series.length < 120) {
+        return {
+          axisBottom: {
+            format: "%d.%b",
+            tickValues: "every 5 days",
+          },
+        }
+      }
       // show format in month.year
       return {
         axisBottom: {
@@ -159,12 +175,44 @@ export const EthBtcChart: VFC<EthBtcChartProps> = ({
         },
       }
     }
-  }, [isLarger768, timeline])
+  }, [isLarger768, timeline, data])
 
   return (
     <LineChart
       {...data.chartProps}
-      {...hourlyAxisBottom}
+      axisBottom={{
+        renderTick: isLarger768
+          ? undefined
+          : (tick) => {
+              const day = tick.value.getDate()
+              const month = tick.value.toLocaleString("default", {
+                month: "short",
+              })
+
+              return (
+                <g transform={`translate(${tick.x},${tick.y + 20})`}>
+                  <text
+                    x={0}
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                    style={{
+                      fill: "white",
+                      fontSize: 12,
+                      fontWeight: 600,
+                    }}
+                  >
+                    <tspan x="0" dy="0">
+                      {day}
+                    </tspan>
+                    <tspan x="0" dy="15">
+                      {month}
+                    </tspan>
+                  </text>
+                </g>
+              )
+            },
+        ...hourlyAxisBottom.axisBottom,
+      }}
       data={data.series || []}
       colors={lineColors}
       enableArea={true}

--- a/src/components/_charts/EthBtcChart.tsx
+++ b/src/components/_charts/EthBtcChart.tsx
@@ -139,7 +139,9 @@ export const EthBtcChart: VFC<EthBtcChartProps> = ({
           format: "%d.%b",
           tickValues:
             timeline === "1W"
-              ? "every 1 day"
+              ? isLarger768
+                ? "every 1 day"
+                : "every 2 days"
               : isLarger768
               ? "every 2 days"
               : "every 5 days",
@@ -151,7 +153,7 @@ export const EthBtcChart: VFC<EthBtcChartProps> = ({
       timeline === "ALL" ||
       timeline === "All"
     ) {
-      if (data.series && data.series.length < 30) {
+      if (data.series && data.series[0].data.length < 30) {
         return {
           axisBottom: {
             format: "%d.%b",
@@ -159,7 +161,7 @@ export const EthBtcChart: VFC<EthBtcChartProps> = ({
           },
         }
       }
-      if (data.series && data.series.length < 120) {
+      if (data.series && data.series[0].data.length < 60) {
         return {
           axisBottom: {
             format: "%d.%b",
@@ -180,39 +182,7 @@ export const EthBtcChart: VFC<EthBtcChartProps> = ({
   return (
     <LineChart
       {...data.chartProps}
-      axisBottom={{
-        renderTick: isLarger768
-          ? undefined
-          : (tick) => {
-              const day = tick.value.getDate()
-              const month = tick.value.toLocaleString("default", {
-                month: "short",
-              })
-
-              return (
-                <g transform={`translate(${tick.x},${tick.y + 20})`}>
-                  <text
-                    x={0}
-                    textAnchor="middle"
-                    dominantBaseline="middle"
-                    style={{
-                      fill: "white",
-                      fontSize: 12,
-                      fontWeight: 600,
-                    }}
-                  >
-                    <tspan x="0" dy="0">
-                      {day}
-                    </tspan>
-                    <tspan x="0" dy="15">
-                      {month}
-                    </tspan>
-                  </text>
-                </g>
-              )
-            },
-        ...hourlyAxisBottom.axisBottom,
-      }}
+      {...hourlyAxisBottom}
       data={data.series || []}
       colors={lineColors}
       enableArea={true}

--- a/src/components/_charts/EthBtcChart.tsx
+++ b/src/components/_charts/EthBtcChart.tsx
@@ -157,7 +157,7 @@ export const EthBtcChart: VFC<EthBtcChartProps> = ({
         return {
           axisBottom: {
             format: "%d.%b",
-            tickValues: "every 3 days",
+            tickValues: isLarger768 ? "every 3 days" : "every 5 days",
           },
         }
       }
@@ -165,7 +165,9 @@ export const EthBtcChart: VFC<EthBtcChartProps> = ({
         return {
           axisBottom: {
             format: "%d.%b",
-            tickValues: "every 5 days",
+            tickValues: isLarger768
+              ? "every 5 days"
+              : "every 10 days",
           },
         }
       }

--- a/src/components/_charts/TokenPriceChart.tsx
+++ b/src/components/_charts/TokenPriceChart.tsx
@@ -153,7 +153,7 @@ export const TokenPriceChart: VFC<TokenPriceChartProps> = ({
         return {
           axisBottom: {
             format: "%d.%b",
-            tickValues: "every 3 days",
+            tickValues: isLarger768 ? "every 3 days" : "every 5 days",
           },
         }
       }
@@ -161,7 +161,9 @@ export const TokenPriceChart: VFC<TokenPriceChartProps> = ({
         return {
           axisBottom: {
             format: "%d.%b",
-            tickValues: "every 5 days",
+            tickValues: isLarger768
+              ? "every 5 days"
+              : "every 10 days",
           },
         }
       }

--- a/src/components/_charts/TokenPriceChart.tsx
+++ b/src/components/_charts/TokenPriceChart.tsx
@@ -120,7 +120,6 @@ export const TokenPriceChart: VFC<TokenPriceChartProps> = ({
   }
 
   const hourlyAxisBottom = useMemo<any>(() => {
-    console.log("timeline", timeline)
     if (timeline === "1D") {
       return {
         axisBottom: {
@@ -148,6 +147,22 @@ export const TokenPriceChart: VFC<TokenPriceChartProps> = ({
       timeline === "ALL" ||
       timeline === "All"
     ) {
+      if (data.series && data.series.length < 30) {
+        return {
+          axisBottom: {
+            format: "%d.%b",
+            tickValues: "every 3 days",
+          },
+        }
+      }
+      if (data.series && data.series.length < 120) {
+        return {
+          axisBottom: {
+            format: "%d.%b",
+            tickValues: "every 5 days",
+          },
+        }
+      }
       // show format in month.year
       return {
         axisBottom: {
@@ -156,12 +171,44 @@ export const TokenPriceChart: VFC<TokenPriceChartProps> = ({
         },
       }
     }
-  }, [isLarger768, timeline])
+  }, [isLarger768, timeline, data])
 
   return (
     <LineChart
       {...data.chartProps}
-      {...hourlyAxisBottom}
+      axisBottom={{
+        renderTick: isLarger768
+          ? undefined
+          : (tick) => {
+              const day = tick.value.getDate()
+              const month = tick.value.toLocaleString("default", {
+                month: "short",
+              })
+
+              return (
+                <g transform={`translate(${tick.x},${tick.y + 20})`}>
+                  <text
+                    x={0}
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                    style={{
+                      fill: "white",
+                      fontSize: 12,
+                      fontWeight: 600,
+                    }}
+                  >
+                    <tspan x="0" dy="0">
+                      {day}
+                    </tspan>
+                    <tspan x="0" dy="15">
+                      {month}
+                    </tspan>
+                  </text>
+                </g>
+              )
+            },
+        ...hourlyAxisBottom.axisBottom,
+      }}
       data={data.series || []}
       colors={lineColors}
       enableArea={true}

--- a/src/components/_charts/TokenPriceChart.tsx
+++ b/src/components/_charts/TokenPriceChart.tsx
@@ -135,7 +135,9 @@ export const TokenPriceChart: VFC<TokenPriceChartProps> = ({
           format: "%d.%b",
           tickValues:
             timeline === "1W"
-              ? "every 1 day"
+              ? isLarger768
+                ? "every 1 day"
+                : "every 2 days"
               : isLarger768
               ? "every 2 days"
               : "every 5 days",
@@ -147,7 +149,7 @@ export const TokenPriceChart: VFC<TokenPriceChartProps> = ({
       timeline === "ALL" ||
       timeline === "All"
     ) {
-      if (data.series && data.series.length < 30) {
+      if (data.series && data.series[0].data.length < 30) {
         return {
           axisBottom: {
             format: "%d.%b",
@@ -155,7 +157,7 @@ export const TokenPriceChart: VFC<TokenPriceChartProps> = ({
           },
         }
       }
-      if (data.series && data.series.length < 120) {
+      if (data.series && data.series[0].data.length < 60) {
         return {
           axisBottom: {
             format: "%d.%b",
@@ -176,39 +178,7 @@ export const TokenPriceChart: VFC<TokenPriceChartProps> = ({
   return (
     <LineChart
       {...data.chartProps}
-      axisBottom={{
-        renderTick: isLarger768
-          ? undefined
-          : (tick) => {
-              const day = tick.value.getDate()
-              const month = tick.value.toLocaleString("default", {
-                month: "short",
-              })
-
-              return (
-                <g transform={`translate(${tick.x},${tick.y + 20})`}>
-                  <text
-                    x={0}
-                    textAnchor="middle"
-                    dominantBaseline="middle"
-                    style={{
-                      fill: "white",
-                      fontSize: 12,
-                      fontWeight: 600,
-                    }}
-                  >
-                    <tspan x="0" dy="0">
-                      {day}
-                    </tspan>
-                    <tspan x="0" dy="15">
-                      {month}
-                    </tspan>
-                  </text>
-                </g>
-              )
-            },
-        ...hourlyAxisBottom.axisBottom,
-      }}
+      {...hourlyAxisBottom}
       data={data.series || []}
       colors={lineColors}
       enableArea={true}

--- a/src/components/_charts/UsdcChart.tsx
+++ b/src/components/_charts/UsdcChart.tsx
@@ -138,7 +138,9 @@ export const UsdcChart: VFC<UsdcChartProps> = ({
           format: "%d.%b",
           tickValues:
             timeline === "1W"
-              ? "every 1 day"
+              ? isLarger768
+                ? "every 1 day"
+                : "every 2 days"
               : isLarger768
               ? "every 2 days"
               : "every 5 days",
@@ -150,7 +152,7 @@ export const UsdcChart: VFC<UsdcChartProps> = ({
       timeline === "ALL" ||
       timeline === "All"
     ) {
-      if (data.series && data.series.length < 30) {
+      if (data.series && data.series[0].data.length < 30) {
         return {
           axisBottom: {
             format: "%d.%b",
@@ -158,7 +160,7 @@ export const UsdcChart: VFC<UsdcChartProps> = ({
           },
         }
       }
-      if (data.series && data.series.length < 120) {
+      if (data.series && data.series[0].data.length < 60) {
         return {
           axisBottom: {
             format: "%d.%b",
@@ -179,39 +181,7 @@ export const UsdcChart: VFC<UsdcChartProps> = ({
   return (
     <LineChart
       {...data.chartProps}
-      axisBottom={{
-        renderTick: isLarger768
-          ? undefined
-          : (tick) => {
-              const day = tick.value.getDate()
-              const month = tick.value.toLocaleString("default", {
-                month: "short",
-              })
-
-              return (
-                <g transform={`translate(${tick.x},${tick.y + 20})`}>
-                  <text
-                    x={0}
-                    textAnchor="middle"
-                    dominantBaseline="middle"
-                    style={{
-                      fill: "white",
-                      fontSize: 12,
-                      fontWeight: 600,
-                    }}
-                  >
-                    <tspan x="0" dy="0">
-                      {day}
-                    </tspan>
-                    <tspan x="0" dy="15">
-                      {month}
-                    </tspan>
-                  </text>
-                </g>
-              )
-            },
-        ...hourlyAxisBottom.axisBottom,
-      }}
+      {...hourlyAxisBottom}
       data={data.series || []}
       colors={lineColors}
       enableArea={true}

--- a/src/components/_charts/UsdcChart.tsx
+++ b/src/components/_charts/UsdcChart.tsx
@@ -156,7 +156,7 @@ export const UsdcChart: VFC<UsdcChartProps> = ({
         return {
           axisBottom: {
             format: "%d.%b",
-            tickValues: "every 3 days",
+            tickValues: isLarger768 ? "every 3 days" : "every 5 days",
           },
         }
       }
@@ -164,7 +164,9 @@ export const UsdcChart: VFC<UsdcChartProps> = ({
         return {
           axisBottom: {
             format: "%d.%b",
-            tickValues: "every 5 days",
+            tickValues: isLarger768
+              ? "every 5 days"
+              : "every 10 days",
           },
         }
       }

--- a/src/components/_charts/UsdcChart.tsx
+++ b/src/components/_charts/UsdcChart.tsx
@@ -150,6 +150,22 @@ export const UsdcChart: VFC<UsdcChartProps> = ({
       timeline === "ALL" ||
       timeline === "All"
     ) {
+      if (data.series && data.series.length < 30) {
+        return {
+          axisBottom: {
+            format: "%d.%b",
+            tickValues: "every 3 days",
+          },
+        }
+      }
+      if (data.series && data.series.length < 120) {
+        return {
+          axisBottom: {
+            format: "%d.%b",
+            tickValues: "every 5 days",
+          },
+        }
+      }
       // show format in month.year
       return {
         axisBottom: {
@@ -158,12 +174,44 @@ export const UsdcChart: VFC<UsdcChartProps> = ({
         },
       }
     }
-  }, [isLarger768, timeline])
+  }, [isLarger768, timeline, data])
 
   return (
     <LineChart
       {...data.chartProps}
-      {...hourlyAxisBottom}
+      axisBottom={{
+        renderTick: isLarger768
+          ? undefined
+          : (tick) => {
+              const day = tick.value.getDate()
+              const month = tick.value.toLocaleString("default", {
+                month: "short",
+              })
+
+              return (
+                <g transform={`translate(${tick.x},${tick.y + 20})`}>
+                  <text
+                    x={0}
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                    style={{
+                      fill: "white",
+                      fontSize: 12,
+                      fontWeight: 600,
+                    }}
+                  >
+                    <tspan x="0" dy="0">
+                      {day}
+                    </tspan>
+                    <tspan x="0" dy="15">
+                      {month}
+                    </tspan>
+                  </text>
+                </g>
+              )
+            },
+        ...hourlyAxisBottom.axisBottom,
+      }}
       data={data.series || []}
       colors={lineColors}
       enableArea={true}


### PR DESCRIPTION
Fixes #1059 

## Description

Describe big picture changes here. This will give viewers context for the changes.

## Changes

List any technical changes.

- [X] Fix All chart problem
if the data is less then 30, then when the timeframe was `all` it will show every 3 days.
if the data is less then 120, then when the timeframe was `all` it will show every 5 days. 
- [X] fix responsive
## Screenshots (if appropriate):

![image](https://github.com/strangelove-ventures/sommelier/assets/1397612/0256cb55-300c-46fc-86d7-078c028f3630)
![image](https://github.com/strangelove-ventures/sommelier/assets/1397612/acf9c3a9-a3bf-4921-9262-c847b4c962d5)
