### PR TITLE
Convert shares -> asset for value netValueWithoutRewardsInAsset

### DIFF
--- a/src/data/actions/common/getUserData.ts
+++ b/src/data/actions/common/getUserData.ts
@@ -114,7 +114,7 @@ export const getUserData = async ({
       ) {
         return undefined
       }
-      return userShares + bonded
+      return (userShares + bonded) * tokenPrice
     })()
 
     const netValue = (() => {
@@ -128,9 +128,7 @@ export const getUserData = async ({
       ) {
         return undefined
       }
-      return (
-        userShares * tokenPrice + bonded * tokenPrice + sommRewardsUSD
-      )
+      return (userShares + bonded) * tokenPrice + sommRewardsUSD
     })()
 
     const netValueWithoutRewards = (() => {


### PR DESCRIPTION
This value was denoted in shares and not assets. Multiplying shares by shareValue will convert it to the base asset value.