### PR TITLE
Zaki/iframe defenses

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -34,6 +34,15 @@ let nextConfig = {
           },
         ],
       },
+      {
+        source: '/(.*)?', // Matches all pages
+        headers: [
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          }
+        ]
+      }
     ]
   },
   redirects: async () => {


### PR DESCRIPTION
Add headers to disable rendering the sommelier application in an iframe
