### PR TITLE
Deny iframe on all pages in the sommelier app

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -34,6 +34,15 @@ let nextConfig = {
           },
         ],
       },
+      {
+        source: '/(.*)?', // Matches all pages
+        headers: [
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          }
+        ]
+      }
     ]
   },
   redirects: async () => {


### PR DESCRIPTION
Deny iframe for app.sommelier.finance pages to prevent click jacking which isn't really a major threat here.
