### PR TITLE
Pass shares to preview redeem instead of assets

### DIFF
--- a/src/components/_cards/PortfolioCard/index.tsx
+++ b/src/components/_cards/PortfolioCard/index.tsx
@@ -85,9 +85,11 @@ export const PortfolioCard: VFC<BoxProps> = (props) => {
     userData?.userStrategyData.userData?.netValueWithoutRewardsInAsset
   const staticCelarConfig = cellarConfig
 
+  const totalShares =
+    userData?.userStrategyData.userData?.totalShares.value
   const { data, isLoading } = useGetPreviewRedeem({
     cellarConfig: staticCelarConfig,
-    value: valueInAssets?.value || 0,
+    value: totalShares?.toString(),
   })
 
   return (

--- a/src/data/actions/common/getPreviewShare.ts
+++ b/src/data/actions/common/getPreviewShare.ts
@@ -1,4 +1,3 @@
-import { ethers } from "ethers"
 import { CellarV0815, CellarV0816 } from "src/abi/types"
 
 export const getPreviewRedeem = async ({
@@ -6,12 +5,11 @@ export const getPreviewRedeem = async ({
   value,
 }: {
   cellarContract: CellarV0815 | CellarV0816
-  value?: number
+  value?: string
 }) => {
   if (!value) return
   try {
-    const convertedValue = ethers.utils.parseUnits(`${value}`, 18)
-    const shares = await cellarContract.previewRedeem(convertedValue)
+    const shares = await cellarContract.previewRedeem(value)
     return {
       value: shares,
     }

--- a/src/data/actions/common/getUserData.ts
+++ b/src/data/actions/common/getUserData.ts
@@ -74,20 +74,21 @@ export const getUserData = async ({
       )
     })()
 
+    const bonded =
+      // Coerce from bignumber.js to ethers BN
+      BigNumber.from(
+        userStakes?.totalBondedAmount?.value
+          ? userStakes?.totalBondedAmount?.value.toFixed()
+          : "0"
+      ) ?? constants.Zero
+    const totalShares = shares.value.add(bonded)
+
     const totalAssets = await (async () => {
       if (!contracts.cellarContract) {
         return ZERO
       }
 
       const cellarContract = contracts.cellarContract as CellarV0815
-      const bonded =
-        // Coerce from bignumber.js to ethers BN
-        BigNumber.from(
-          userStakes?.totalBondedAmount?.value
-            ? userStakes?.totalBondedAmount?.value.toFixed()
-            : "0"
-        ) ?? constants.Zero
-      const totalShares = shares.value.add(bonded)
       let assets = await cellarContract.convertToAssets(totalShares)
 
       if (typeof assets === "undefined") {
@@ -97,10 +98,6 @@ export const getUserData = async ({
     })()
 
     const numTotalAssets = Number(totalAssets.toNumber().toFixed(5))
-
-    const bonded = userStakes
-      ? Number(userStakes.totalBondedAmount.formatted)
-      : 0
 
     const sommRewardsUSD = userStakes
       ? userStakes.claimAllRewardsUSD.toNumber()
@@ -169,6 +166,9 @@ export const getUserData = async ({
           userStakes?.totalClaimAllRewards || undefined,
         userStakes,
         symbol: subgraphData?.asset.symbol,
+        totalShares: {
+          value: totalShares,
+        },
       },
     }
 

--- a/src/data/hooks/useGetPreviewRedeem.ts
+++ b/src/data/hooks/useGetPreviewRedeem.ts
@@ -9,7 +9,7 @@ export const useGetPreviewRedeem = ({
   value,
 }: {
   cellarConfig: ConfigProps
-  value: number
+  value?: string
 }) => {
   const { cellarContract } = useCreateContracts(cellarConfig)
   const user = useAccount()
@@ -19,7 +19,7 @@ export const useGetPreviewRedeem = ({
       { config: cellarConfig.id, value, userAddress: user.address },
     ],
     async () => {
-      if (!cellarContract || !value) throw new Error("Missing data")
+      if (!cellarContract) throw new Error("Missing data")
       const data = await getPreviewRedeem({
         cellarContract,
         value,


### PR DESCRIPTION
Fixes:
https://github.com/strangelove-ventures/sommelier/issues/1109

Preview redeem expects shares, not assets.

<img width="743" alt="image" src="https://github.com/strangelove-ventures/sommelier/assets/1229188/3c25d2fd-b089-4560-9fdc-00317981621a">
