### PR TITLE
Migrate v1 & v1.5 cellars to use APY since inception

### DIFF
--- a/src/data/actions/common/getApyInception.ts
+++ b/src/data/actions/common/getApyInception.ts
@@ -1,7 +1,7 @@
 import { differenceInDays } from "date-fns"
 import BigNumber from "bignumber.js"
 
-export const getBaseApy = ({
+export const getApyInception = ({
   baseApy,
   dayDatas,
   hardcodedApy,

--- a/src/data/actions/common/getApyInception.ts
+++ b/src/data/actions/common/getApyInception.ts
@@ -14,7 +14,7 @@ export const getApyInception = ({
   hardcodedApy?: boolean
   launchEpoch: number
   decimals: number
-  startingShareValue?: string
+  startingShareValue?: string | undefined | null
 }) => {
   const isDataNotValid =
     !dayDatas || dayDatas?.length === 1 || dayDatas?.length < 2

--- a/src/data/actions/common/getStrategyData.ts
+++ b/src/data/actions/common/getStrategyData.ts
@@ -1,5 +1,5 @@
 import { cellarDataMap } from "data/cellarDataMap"
-import { CellarKey, ConfigProps } from "data/types"
+import { ConfigProps } from "data/types"
 import {
   estimatedApyValue,
   isAPYEnabled,
@@ -16,7 +16,6 @@ import { getRewardsApy } from "./getRewardsApy"
 import { getBaseApy as getV2BaseApy } from "../CELLAR_V2/getBaseApy"
 import { getActiveAsset } from "../DEPRECATED/common/getActiveAsset"
 import { StrategyContracts } from "../types"
-import { getBaseApy } from "./getBaseApy"
 import { getChanges } from "./getChanges"
 import { getPositon } from "./getPosition"
 import { getTokenByAddress, getTokenBySymbol } from "./getToken"
@@ -157,20 +156,24 @@ export const getStrategyData = async ({
         if (!isAPYEnabled(config)) return
         const datas = dayDatas?.slice(0, 10)
 
-        if (config.cellar.key === CellarKey.CELLAR_V2) {
-          const launchDay = launchDate ?? subDays(new Date(), 8)
-          const launchEpoch = Math.floor(launchDay.getTime() / 1000)
+        const launchDay = launchDate ?? subDays(new Date(), 8)
+        const launchEpoch = Math.floor(launchDay.getTime() / 1000)
+
+        if (strategy.startingShareValue != null) {
           return getV2BaseApy({
             launchEpoch: launchEpoch,
             baseApy: config.baseApy,
             dayDatas: datas,
             decimals: decimals,
+            startingShareValue: strategy.startingShareValue,
           })
         }
 
-        return getBaseApy({
+        return getV2BaseApy({
+          launchEpoch: launchEpoch,
           baseApy: config.baseApy,
           dayDatas: datas,
+          decimals: decimals,
         })
       })()
 

--- a/src/data/actions/common/getStrategyData.ts
+++ b/src/data/actions/common/getStrategyData.ts
@@ -159,21 +159,12 @@ export const getStrategyData = async ({
         const launchDay = launchDate ?? subDays(new Date(), 8)
         const launchEpoch = Math.floor(launchDay.getTime() / 1000)
 
-        if (strategy.startingShareValue != null) {
-          return getApyInception({
-            launchEpoch: launchEpoch,
-            baseApy: config.baseApy,
-            dayDatas: datas,
-            decimals: decimals,
-            startingShareValue: strategy.startingShareValue,
-          })
-        }
-
         return getApyInception({
           launchEpoch: launchEpoch,
           baseApy: config.baseApy,
           dayDatas: datas,
           decimals: decimals,
+          startingShareValue: strategy.startingShareValue,
         })
       })()
 

--- a/src/data/actions/common/getStrategyData.ts
+++ b/src/data/actions/common/getStrategyData.ts
@@ -13,7 +13,6 @@ import { formatDecimals } from "utils/bigNumber"
 import { isComingSoon } from "utils/isComingSoon"
 import { getStakingEnd } from "../CELLAR_STAKING_V0815/getStakingEnd"
 import { getRewardsApy } from "./getRewardsApy"
-import { getBaseApy as getV2BaseApy } from "../CELLAR_V2/getBaseApy"
 import { getActiveAsset } from "../DEPRECATED/common/getActiveAsset"
 import { StrategyContracts } from "../types"
 import { getChanges } from "./getChanges"
@@ -21,6 +20,7 @@ import { getPositon } from "./getPosition"
 import { getTokenByAddress, getTokenBySymbol } from "./getToken"
 import { getTvm } from "./getTvm"
 import { getTokenPrice } from "./getTokenPrice"
+import { getApyInception } from "./getApyInception"
 
 export const getStrategyData = async ({
   address,
@@ -160,7 +160,7 @@ export const getStrategyData = async ({
         const launchEpoch = Math.floor(launchDay.getTime() / 1000)
 
         if (strategy.startingShareValue != null) {
-          return getV2BaseApy({
+          return getApyInception({
             launchEpoch: launchEpoch,
             baseApy: config.baseApy,
             dayDatas: datas,
@@ -169,7 +169,7 @@ export const getStrategyData = async ({
           })
         }
 
-        return getV2BaseApy({
+        return getApyInception({
           launchEpoch: launchEpoch,
           baseApy: config.baseApy,
           dayDatas: datas,

--- a/src/data/strategies/eth-btc-trend.ts
+++ b/src/data/strategies/eth-btc-trend.ts
@@ -19,6 +19,9 @@ export const ethBtcTrend: CellarData = {
     "Strategy portfolio buys BTC and ETH when prices go up. Fully or partially sells both assets when prices go down.",
   strategyType: "Crypto portfolio",
   strategyTypeTooltip: "Strategy takes long positions in crypto",
+  // There was an issue at launch with the ETH-BTC Trend Cellar
+  // where the initial share value was about $2
+  startingShareValue: "1999911",
   managementFee: "2.00%",
   managementFeeTooltip:
     "Platform fee split: 1.5% for Strategy provider and 0.5% for protocol",

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -88,6 +88,7 @@ export interface CellarData {
   description: string
   strategyType: string
   strategyTypeTooltip?: string
+  startingShareValue?: string
   managementFee: string
   managementFeeTooltip?: string
   protocols: string | string[]


### PR DESCRIPTION
- Rename old v2 `getBaseApy` to common `getApyInception`
- Allow configurable starting value for `shareValue`
- Configure ETH-BTC Trend Cellar correct starting share value
- Migrate all cellars to use since inception APY calc