### PR TITLE
Multiply totalAssets by asset price, not cellar share value

### DIFF
--- a/src/data/actions/common/getUserData.ts
+++ b/src/data/actions/common/getUserData.ts
@@ -127,12 +127,14 @@ export const getUserData = async ({
 
     // Denoted in USD
     const netValue = (() => {
-      return numTotalAssets * tokenPrice + sommRewardsUSD
+      return totalAssets
+        .multipliedBy(baseAssetPrice)
+        .plus(sommRewardsUSD)
     })()
 
     // Denoted in USD
     const netValueWithoutRewards = (() => {
-      return numTotalAssets * tokenPrice
+      return totalAssets.multipliedBy(baseAssetPrice)
     })()
 
     const userStrategyData = {


### PR DESCRIPTION
Bug, user deposited $950 but net value is showing $969 and user has no rewards:
![telegram-cloud-photo-size-1-4943081327461248504-y](https://github.com/strangelove-ventures/sommelier/assets/1229188/4adc959b-b838-4431-adf6-816828b2480b)

Fixed:
<img width="658" alt="image" src="https://github.com/strangelove-ventures/sommelier/assets/1229188/78c39abb-08b9-4506-b921-c6e5d2051d4a">
