### PR TITLE
Increase cache window for coingecko

### DIFF
--- a/src/pages/api/coingecko-simple-price.ts
+++ b/src/pages/api/coingecko-simple-price.ts
@@ -47,7 +47,7 @@ const coinGeckoSimplePrice = async (
     const price = result[baseId][quoteId]
     res.setHeader(
       "Cache-Control",
-      "public, max-age=10, s-maxage=30, stale-while-revalidate=59"
+      "public, max-age=60, s-maxage=60, stale-while-revalidate=7200"
     )
     res.setHeader("Access-Control-Allow-Origin", baseUrl)
     res.status(200).json({


### PR DESCRIPTION
Coingecko takes up to 4s to load, cache window is too small; this increases it to the same cache params as the slow graph queries.