### PR TITLE
platform-fees-tooltip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ studio/node_modules
 *.log
 .vscode/
 !.env.example
+.env*.local

--- a/src/data/strategies/defi-stars.ts
+++ b/src/data/strategies/defi-stars.ts
@@ -22,7 +22,7 @@ export const defiStars: CellarData = {
   strategyTypeTooltip: "Strategy takes long positions in crypto",
   managementFee: "2.00%",
   managementFeeTooltip:
-    "Platform fee split: 1.5% for Strategy provider and 0.5% for protocol",
+    "An annual charge on your deposited amount for the pro-rated period during which your deposit remains in the vault",
   protocols: ["Uniswap V3", "1inch", "0x"],
   strategyAssets: ["COMP", "CRV", "LDO", "MKR", "AAVE", "USDC"],
   performanceSplit: {

--- a/src/data/strategies/eth-btc-momentum.ts
+++ b/src/data/strategies/eth-btc-momentum.ts
@@ -20,7 +20,7 @@ export const ethBtcMomentum: CellarData = {
   strategyTypeTooltip: "Strategy takes long positions in crypto",
   managementFee: "2.00%",
   managementFeeTooltip:
-    "Platform fee split: 1.5% for Strategy provider and 0.5% for protocol",
+    "An annual charge on your deposited amount for the pro-rated period during which your deposit remains in the vault",
   protocols: "Uniswap V3",
   strategyAssets: ["WBTC", "WETH", "USDC"],
   performanceSplit: {

--- a/src/data/strategies/eth-btc-trend.ts
+++ b/src/data/strategies/eth-btc-trend.ts
@@ -24,7 +24,7 @@ export const ethBtcTrend: CellarData = {
   startingShareValue: "1999911",
   managementFee: "2.00%",
   managementFeeTooltip:
-    "Platform fee split: 1.5% for Strategy provider and 0.5% for protocol",
+    "An annual charge on your deposited amount for the pro-rated period during which your deposit remains in the vault",
   protocols: "Uniswap V3",
   strategyAssets: ["WBTC", "WETH", "USDC"],
   performanceSplit: {

--- a/src/data/strategies/fraximal.ts
+++ b/src/data/strategies/fraximal.ts
@@ -21,7 +21,8 @@ export const fraximal: CellarData = {
   strategyType: "Yield",
   strategyTypeTooltip: "Strategy takes long positions in crypto",
   managementFee: "0.00%",
-  managementFeeTooltip: "Platform fee 0.00%",
+  managementFeeTooltip:
+    "An annual charge on your deposited amount for the pro-rated period during which your deposit remains in the vault",
   protocols: ["Fraxlend"],
   strategyAssets: ["FRAX"],
   performanceSplit: {

--- a/src/data/strategies/real-yield-1inch.ts
+++ b/src/data/strategies/real-yield-1inch.ts
@@ -18,7 +18,7 @@ export const realYield1Inch: CellarData = {
   strategyTypeTooltip: "Strategy takes long positions in crypto",
   managementFee: "0.00%",
   managementFeeTooltip:
-    "Platform fee split: 0% for Strategy provider and 0% for protocol",
+    "An annual charge on your deposited amount for the pro-rated period during which your deposit remains in the vault",
   protocols: ["AAVE"],
   strategyAssets: ["1INCH", "WETH", "YieldETH"],
   performanceSplit: {

--- a/src/data/strategies/real-yield-btc.ts
+++ b/src/data/strategies/real-yield-btc.ts
@@ -19,7 +19,7 @@ export const realYieldBTC: CellarData = {
   strategyTypeTooltip: "Strategy takes long positions in crypto",
   managementFee: "1.00%",
   managementFeeTooltip:
-    "Platform fee split: 0.75% for Strategy provider and 0.25% for protocol",
+    "An annual charge on your deposited amount for the pro-rated period during which your deposit remains in the vault",
   protocols: ["Morpho", "AAVE", "Uniswap V3"],
   strategyAssets: ["WBTC", "WETH"],
   performanceSplit: {

--- a/src/data/strategies/real-yield-ens.ts
+++ b/src/data/strategies/real-yield-ens.ts
@@ -18,7 +18,7 @@ export const realYieldENS: CellarData = {
   strategyTypeTooltip: "Strategy takes long positions in crypto",
   managementFee: "0.00%",
   managementFeeTooltip:
-    "Platform fee split: 0% for Strategy provider and 0% for protocol",
+    "An annual charge on your deposited amount for the pro-rated period during which your deposit remains in the vault",
   protocols: ["AAVE"],
   strategyAssets: ["ENS", "WETH", "YieldETH"],
   performanceSplit: {

--- a/src/data/strategies/real-yield-eth.ts
+++ b/src/data/strategies/real-yield-eth.ts
@@ -22,7 +22,7 @@ export const realYieldEth: CellarData = {
   strategyTypeTooltip: "Strategy takes long positions in crypto",
   managementFee: "1.00%",
   managementFeeTooltip:
-    "Platform fee split: 0.75% for Strategy provider and 0.25% for protocol",
+    "An annual charge on your deposited amount for the pro-rated period during which your deposit remains in the vault",
   protocols: ["AAVE", "Compound", "Uniswap V3", "Morpho"],
   strategyAssets: ["stETH", "cbETH", "rETH", "WETH"],
   performanceSplit: {

--- a/src/data/strategies/real-yield-link.ts
+++ b/src/data/strategies/real-yield-link.ts
@@ -18,7 +18,7 @@ export const realYieldLink: CellarData = {
   strategyTypeTooltip: "Strategy takes long positions in crypto",
   managementFee: "0.00%",
   managementFeeTooltip:
-    "Platform fee split: 0% for Strategy provider and 0% for protocol",
+    "An annual charge on your deposited amount for the pro-rated period during which your deposit remains in the vault",
   protocols: ["AAVE"],
   strategyAssets: ["LINK", "WETH", "YieldETH"],
   performanceSplit: {

--- a/src/data/strategies/real-yield-snx.ts
+++ b/src/data/strategies/real-yield-snx.ts
@@ -18,7 +18,7 @@ export const realYieldSNX: CellarData = {
   strategyTypeTooltip: "Strategy takes long positions in crypto",
   managementFee: "0.00%",
   managementFeeTooltip:
-    "Platform fee split: 0% for Strategy provider and 0% for protocol",
+    "An annual charge on your deposited amount for the pro-rated period during which your deposit remains in the vault",
   protocols: ["AAVE"],
   strategyAssets: ["SNX", "WETH", "YieldETH"],
   performanceSplit: {

--- a/src/data/strategies/real-yield-uni.ts
+++ b/src/data/strategies/real-yield-uni.ts
@@ -17,7 +17,7 @@ export const realYieldUNI: CellarData = {
   strategyTypeTooltip: "Strategy takes long positions in crypto",
   managementFee: "0.00%",
   managementFeeTooltip:
-    "Platform fee split: 0% for Strategy provider and 0% for protocol",
+    "An annual charge on your deposited amount for the pro-rated period during which your deposit remains in the vault",
   protocols: ["AAVE"],
   strategyAssets: ["UNI", "WETH", "YieldETH"],
   performanceSplit: {

--- a/src/data/strategies/real-yield-usd.ts
+++ b/src/data/strategies/real-yield-usd.ts
@@ -20,9 +20,9 @@ export const realYieldUsd: CellarData = {
   description: `The only strategy in Defi to maximize USDC, USDT, and DAI yields across Aave, Compound and Uniswap V3.`,
   strategyType: "Stablecoin",
   strategyTypeTooltip: "Strategy takes long positions in crypto",
-  managementFee: "0.50%",
+  managementFee: "0.00%",
   managementFeeTooltip:
-    "Platform fee split: 0.4% for Strategy provider and 0.1% for protocol",
+    "An annual charge on your deposited amount for the pro-rated period during which your deposit remains in the vault",
   protocols: ["AAVE", "Compound", "Uniswap V3", "Morpho"],
   strategyAssets: ["USDC", "USDT", "DAI"],
   performanceSplit: {

--- a/src/data/strategies/steady-btc.ts
+++ b/src/data/strategies/steady-btc.ts
@@ -21,7 +21,7 @@ export const steadyBtc: CellarData = {
   strategyTypeTooltip: "Strategy takes long positions in crypto",
   managementFee: "2.00%",
   managementFeeTooltip:
-    "Platform fee split: 1.5% for Strategy provider and 0.5% for protocol",
+    "An annual charge on your deposited amount for the pro-rated period during which your deposit remains in the vault",
   protocols: "Uniswap V3",
   strategyAssets: ["WBTC", "USDC"],
   performanceSplit: {

--- a/src/data/strategies/steady-eth.ts
+++ b/src/data/strategies/steady-eth.ts
@@ -21,7 +21,7 @@ export const steadyEth: CellarData = {
   strategyTypeTooltip: "Strategy takes long positions in crypto",
   managementFee: "2.00%",
   managementFeeTooltip:
-    "Platform fee split: 1.5% for Strategy provider and 0.5% for protocol",
+    "An annual charge on your deposited amount for the pro-rated period during which your deposit remains in the vault",
   protocols: "Uniswap V3",
   strategyAssets: ["WETH", "USDC"],
   performanceSplit: {

--- a/src/data/strategies/steady-matic.ts
+++ b/src/data/strategies/steady-matic.ts
@@ -21,7 +21,7 @@ export const steadyMatic: CellarData = {
   strategyTypeTooltip: "Strategy takes long positions in crypto",
   managementFee: "2.00%",
   managementFeeTooltip:
-    "Platform fee split: 1.5% for Strategy provider and 0.5% for protocol",
+    "An annual charge on your deposited amount for the pro-rated period during which your deposit remains in the vault",
   protocols: "Uniswap V3",
   strategyAssets: ["USDC"],
   performanceSplit: {

--- a/src/data/strategies/steady-uni.ts
+++ b/src/data/strategies/steady-uni.ts
@@ -21,7 +21,7 @@ export const steadyUni: CellarData = {
   strategyTypeTooltip: "Strategy takes long positions in crypto",
   managementFee: "2.00%",
   managementFeeTooltip:
-    "Platform fee split: 1.5% for Strategy provider and 0.5% for protocol",
+    "An annual charge on your deposited amount for the pro-rated period during which your deposit remains in the vault",
   protocols: "Uniswap V3",
   strategyAssets: ["USDC"],
   performanceSplit: {


### PR DESCRIPTION
Fixes #<ISSUE_NUMBER>

## Description

Changed Platform Fee tooltip for all strategies to- “An annual charge on your deposited amount for the pro-rated period during which your deposit remains in the vault”

Changed platform fee for RYUSD to 0.00%



## Changes

List any technical changes.

- [ ] Change 1

## Screenshots (if appropriate):

## Testing Steps

As a reviewer, what steps should I take to verify this is working correctly?

- [ ] Step 1

## Links

Add links to Figma files, documentation, etc.
