### PR TITLE
Base apy to net apy

### DIFF
--- a/src/components/_charts/ApyChart.tsx
+++ b/src/components/_charts/ApyChart.tsx
@@ -217,7 +217,7 @@ export const ApyChart: VFC<TokenPriceChartProps> = ({
                   fill: "rgb(237, 235, 245)",
                 }}
               >
-                {tick.value} % 
+                {tick.value} %
               </text>
             </g>
           )

--- a/src/components/_columns/StrategyDesktopColumn.tsx
+++ b/src/components/_columns/StrategyDesktopColumn.tsx
@@ -207,10 +207,18 @@ export const StrategyDesktopColumn = ({
     },
     {
       Header: () => (
-        <Text>
-          Base APY
-          <br />& Rewards
-        </Text>
+        <Tooltip
+          arrowShadowColor="purple.base"
+          label="APY before any platform and strategy provider fees, inclusive of rewards program earnings when an active rewards program is in place"
+          placement="top"
+          color="neutral.300"
+          bg="surface.bg"
+        >
+          <HStack spacing={1}>
+            <Text>Net APY</Text>
+            <InformationIcon color="neutral.400" boxSize={3} />
+          </HStack>
+        </Tooltip>
       ),
       accessor: "baseApy",
       Cell: ({ row }: any) => {

--- a/src/components/_columns/StrategyTabColumn.tsx
+++ b/src/components/_columns/StrategyTabColumn.tsx
@@ -1,4 +1,4 @@
-import { Text, Tooltip, VStack } from "@chakra-ui/react"
+import { Text, Tooltip, VStack, HStack } from "@chakra-ui/react"
 import { PercentageText } from "components/PercentageText"
 import { DepositAndWithdrawButton } from "components/_buttons/DepositAndWithdrawButton"
 import { ApyRewardsSection } from "components/_tables/ApyRewardsSection"
@@ -7,6 +7,7 @@ import { Timeline } from "data/context/homeContext"
 import { DepositModalType } from "data/hooks/useDepositModalStore"
 import { isTokenPriceEnabledApp } from "data/uiConfig"
 import { cellarDataMap } from "data/cellarDataMap"
+import { InformationIcon } from "components/_icons"
 
 type StrategyTabColumnProps = {
   timeline: Timeline
@@ -37,7 +38,9 @@ export const StrategyTabColumn = ({
             date={row.original.launchDate}
             description={row.original.description}
             isDeprecated={row.original.deprecated}
-            customStrategyHighlight={row.original.config.customStrategyHighlight}
+            customStrategyHighlight={
+              row.original.config.customStrategyHighlight
+            }
             w={56}
           />
         )
@@ -58,10 +61,18 @@ export const StrategyTabColumn = ({
     },
     {
       Header: () => (
-        <Text>
-          Base APY
-          <br />& Rewards
-        </Text>
+        <Tooltip
+          arrowShadowColor="purple.base"
+          label="APY before any platform and strategy provider fees, inclusive of rewards program earnings when an active rewards program is in place"
+          placement="top"
+          color="neutral.300"
+          bg="surface.bg"
+        >
+          <HStack spacing={1}>
+            <Text>Net APY</Text>
+            <InformationIcon color="neutral.400" boxSize={3} />
+          </HStack>
+        </Tooltip>
       ),
       accessor: "baseApy",
       Cell: ({ row }: any) => {


### PR DESCRIPTION
Fixes #<ISSUE_NUMBER>

## Description

1. "APY Since Inception" to "Net APY"
![Screenshot 2023-09-06 at 13 56 07](https://github.com/strangelove-ventures/sommelier/assets/26877917/ecf0bc44-7e7c-4e6e-80a0-435970ee160b)


2. "Base APY" to "APY Since Inception"
![Screenshot 2023-09-06 at 13 55 58](https://github.com/strangelove-ventures/sommelier/assets/26877917/f0c7d1b6-0eaa-476c-8655-6e66a940cb35)


3. Base APY & Rewards to "Net APY" + tooltip
![Screenshot 2023-09-06 at 13 55 51](https://github.com/strangelove-ventures/sommelier/assets/26877917/ef0dae95-fd68-4377-9e8c-981e9aabea67)


**TODO NEXT:**

1. Create the parameter "30D Moving Average APY"
2. Create a list in the UI config file to replace places where we use "APY since inception" with "30D Moving Average APY"


