### PR TITLE
turbo-somm&stETH&stETH2-hide-bonding-UI

### DIFF
--- a/src/data/uiConfig.ts
+++ b/src/data/uiConfig.ts
@@ -48,6 +48,7 @@ export const isBondedDisabled = (config: ConfigProps) => {
     config.cellarNameKey === CellarNameKey.REAL_YIELD_1INCH ||
     config.cellarNameKey === CellarNameKey.REAL_YIELD_ENS ||
     config.cellarNameKey === CellarNameKey.REAL_YIELD_SNX ||
+    config.cellarNameKey === CellarNameKey.TURBO_SOMM ||
     config.cellarNameKey === CellarNameKey.REAL_YIELD_UNI
   )
 }
@@ -480,7 +481,7 @@ export const apyHoverLabel = (config: ConfigProps) => {
       return "Estimated APY"
     } /*else if (config.cellarNameKey === CellarNameKey.TURBO_SWETH) {
       return "7 Day MA APY (includes swETH incentives)"
-    } */else if (config.cellarNameKey === CellarNameKey.TURBO_SOMM) {
+    } */ else if (config.cellarNameKey === CellarNameKey.TURBO_SOMM) {
       return "Estimated Reward APY (excluding impermanent loss)"
     }
     return "30D MA APY"
@@ -501,7 +502,7 @@ export const baseApyHoverLabel = (config: ConfigProps) => {
     return "Estimated APY"
   } /*else if (config.cellarNameKey === CellarNameKey.TURBO_SWETH) {
     return "7 Day MA APY (includes swETH incentives)"
-  } */else if (config.cellarNameKey === CellarNameKey.TURBO_SOMM) {
+  } */ else if (config.cellarNameKey === CellarNameKey.TURBO_SOMM) {
     return "Estimated Reward APY (excluding impermanent loss)"
   }
   return "30D MA APY"

--- a/src/data/uiConfig.ts
+++ b/src/data/uiConfig.ts
@@ -49,6 +49,9 @@ export const isBondedDisabled = (config: ConfigProps) => {
     config.cellarNameKey === CellarNameKey.REAL_YIELD_ENS ||
     config.cellarNameKey === CellarNameKey.REAL_YIELD_SNX ||
     config.cellarNameKey === CellarNameKey.TURBO_SOMM ||
+    config.cellarNameKey === CellarNameKey.TURBO_STETH ||
+    config.cellarNameKey ===
+      CellarNameKey.TURBO_STETH_STETH_DEPOSIT ||
     config.cellarNameKey === CellarNameKey.REAL_YIELD_UNI
   )
 }


### PR DESCRIPTION
We dont want to show "Bonding" related things if rewards program is via vesting contract as there is anyway no option to bond.

Current solution:
<img width="413" alt="Screenshot 2023-12-11 at 16 46 06" src="https://github.com/strangelove-ventures/sommelier/assets/26877917/749eb752-b827-4628-b2e2-0df97565bd74">


Expected solution:
<img width="272" alt="Screenshot 2023-12-11 at 16 46 17" src="https://github.com/strangelove-ventures/sommelier/assets/26877917/5ffaff6f-c79b-49fb-9028-dfce04025eec">
