### PR TITLE
RYLINK-withdraw queue button

### DIFF
--- a/src/components/_cards/PortfolioCard/index.tsx
+++ b/src/components/_cards/PortfolioCard/index.tsx
@@ -55,6 +55,7 @@ import { useNetwork } from "wagmi"
 import WithdrawQueueCard from "../WithdrawQueueCard"
 import withdrawQueueV0821 from "src/abi/withdraw-queue-v0.8.21.json"
 import { add } from "lodash"
+import { CellarNameKey } from "data/types"
 
 export const PortfolioCard: VFC<BoxProps> = (props) => {
   const theme = useTheme()
@@ -276,12 +277,15 @@ export const PortfolioCard: VFC<BoxProps> = (props) => {
                             }
                           />
                         )}
-                        <WithdrawButton
-                          isDeprecated={strategyData?.deprecated}
-                          disabled={
-                            lpTokenDisabled || !buttonsEnabled
-                          }
-                        />
+                        {cellarConfig.cellarNameKey !==
+                          CellarNameKey.REAL_YIELD_LINK && (
+                          <WithdrawButton
+                            isDeprecated={strategyData?.deprecated}
+                            disabled={
+                              lpTokenDisabled || !buttonsEnabled
+                            }
+                          />
+                        )}
                       </HStack>
                       {/*
                       <>
@@ -297,6 +301,14 @@ export const PortfolioCard: VFC<BoxProps> = (props) => {
                         />
                       </>
                         */}
+                      {cellarConfig.cellarNameKey ===
+                        CellarNameKey.REAL_YIELD_LINK && (
+                        <WithdrawQueueButton
+                          chain={cellarConfig.chain}
+                          buttonLabel="Enter Withdraw Queue"
+                          showTooltip={true}
+                        />
+                      )}
                     </VStack>
                   </>
                 ) : (


### PR DESCRIPTION
Request: Front End needs custom logic to automatically show the withdraw queue for Real Yield LINK.

**as is:**
<img width="267" alt="Screenshot 2024-02-24 at 22 13 46" src="https://github.com/PeggyJV/sommelier-strangelove/assets/26877917/d29b0b3d-e0a3-4e42-8267-275f01613956">

**to be:**
<img width="314" alt="Screenshot 2024-02-24 at 22 13 03" src="https://github.com/PeggyJV/sommelier-strangelove/assets/26877917/794641fa-89ed-4e49-8ed6-cf96535600b7">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced portfolio cards to include dynamic rendering of withdrawal options based on cellar configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->