### PR TITLE
Turbo reth fixes

### DIFF
--- a/src/data/strategies/turbo-rseth.ts
+++ b/src/data/strategies/turbo-rseth.ts
@@ -41,7 +41,7 @@ export const turborsETH: CellarData = {
 
     highlights: `
     - Accepts WETH and rsETH deposits.
-    - Leverage loop rsETH for more EigenLayer and Renzo points (subject to borrow capacity on Morpho Blue).
+    - Leverage loop rsETH for more EigenLayer and Kelp Miles (subject to borrow capacity on Morpho Blue).
     - Dynamically liquidity provision across multiple DEXs.
     - Fully automated with built-in auto compounding.`,
 

--- a/src/data/strategyPageContentData.tsx
+++ b/src/data/strategyPageContentData.tsx
@@ -839,7 +839,7 @@ export const strategyPageContentData = {
     strategyHighlights: {
       card: [
         `Accepts WETH and rsETH deposits.`,
-        `Leverage loop rsETH for more EigenLayer and Renzo points (subject to borrow capacity on Morpho Blue).`,
+        `Leverage loop rsETH for more EigenLayer and Kelp Miles (subject to borrow capacity on Morpho Blue).`,
         `Dynamically liquidity provision across multiple DEXs.`,
         `Fully automated with built-in auto compounding.`,
       ],

--- a/src/data/uiConfig.ts
+++ b/src/data/uiConfig.ts
@@ -690,6 +690,12 @@ export const estimatedApyValue = (config: ConfigProps) => {
       formatted: "6.0%",
     }
   }
+  if (config.cellarNameKey === CellarNameKey.TURBO_RSETH) {
+    return {
+      value: 8.0,
+      formatted: "8.0%",
+    }
+  }
 }
 export const showNetValueInAsset = (config: ConfigProps) => {
   if (config.cellarNameKey === CellarNameKey.REAL_YIELD_ETH) {


### PR DESCRIPTION
Added Estimated APY 8.00%
 Kelp Miles instead of Renzo Points

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new APY estimation logic for the turbo-rsETH strategy, now showing an estimated value of 8.0%.

- **Refactor**
	- Updated rewards terminology across the platform:
		- Renamed "Renzo points" to "Kelp Miles" within the turbo-rsETH strategy context.
		- Updated platform texts to reflect the new terminology for rewards from EigenLayer as "Kelp Miles" instead of "Renzo points".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->