### PR TITLE
Turbo-rsETH Estimated APY

### DIFF
--- a/src/data/strategies/turbo-rseth.ts
+++ b/src/data/strategies/turbo-rseth.ts
@@ -41,7 +41,7 @@ export const turborsETH: CellarData = {
 
     highlights: `
     - Accepts WETH and rsETH deposits.
-    - Leverage loop rsETH for more EigenLayer and Renzo points (subject to borrow capacity on Morpho Blue).
+    - Leverage loop rsETH for more EigenLayer and Kelp Miles (subject to borrow capacity on Morpho Blue).
     - Dynamically liquidity provision across multiple DEXs.
     - Fully automated with built-in auto compounding.`,
 

--- a/src/data/strategyPageContentData.tsx
+++ b/src/data/strategyPageContentData.tsx
@@ -839,7 +839,7 @@ export const strategyPageContentData = {
     strategyHighlights: {
       card: [
         `Accepts WETH and rsETH deposits.`,
-        `Leverage loop rsETH for more EigenLayer and Renzo points (subject to borrow capacity on Morpho Blue).`,
+        `Leverage loop rsETH for more EigenLayer and Kelp Miles (subject to borrow capacity on Morpho Blue).`,
         `Dynamically liquidity provision across multiple DEXs.`,
         `Fully automated with built-in auto compounding.`,
       ],

--- a/src/data/uiConfig.ts
+++ b/src/data/uiConfig.ts
@@ -510,6 +510,7 @@ export const apyLabel = (config: ConfigProps) => {
       config.cellarNameKey === CellarNameKey.TURBO_SOMM ||
       config.cellarNameKey === CellarNameKey.TURBO_DIVETH ||
       config.cellarNameKey === CellarNameKey.TURBO_ETHX ||
+      config.cellarNameKey === CellarNameKey.TURBO_RSETH ||
       config.cellarNameKey ===
         CellarNameKey.TEST_ARBITRUM_MULTI_ASSET_DEPOSIT
     ) {
@@ -565,6 +566,7 @@ export const baseApyHoverLabel = (config: ConfigProps) => {
     config.cellarNameKey === CellarNameKey.TURBO_ETHX ||
     config.cellarNameKey === CellarNameKey.REAL_YIELD_ETH_ARB ||
     config.cellarNameKey === CellarNameKey.REAL_YIELD_USD_ARB ||
+    config.cellarNameKey === CellarNameKey.TURBO_RSETH ||
     config.cellarNameKey === CellarNameKey.REAL_YIELD_UNI
   ) {
     return "Estimated APY"
@@ -592,6 +594,7 @@ export const isEstimatedApyEnable = (config: ConfigProps) => {
     config.cellarNameKey === CellarNameKey.TURBO_EETHV2 ||
     config.cellarNameKey === CellarNameKey.TURBO_DIVETH ||
     config.cellarNameKey === CellarNameKey.TURBO_ETHX ||
+    config.cellarNameKey === CellarNameKey.TURBO_RSETH ||
     config.cellarNameKey === CellarNameKey.TURBO_SOMM
   ) {
     return true
@@ -613,6 +616,7 @@ export const apyChartLabel = (config: ConfigProps) => {
     config.cellarNameKey === CellarNameKey.TURBO_SOMM ||
     config.cellarNameKey === CellarNameKey.TURBO_DIVETH ||
     config.cellarNameKey === CellarNameKey.TURBO_ETHX ||
+    config.cellarNameKey === CellarNameKey.TURBO_RSETH ||
     config.cellarNameKey ===
       CellarNameKey.TEST_ARBITRUM_MULTI_ASSET_DEPOSIT
   ) {
@@ -688,6 +692,12 @@ export const estimatedApyValue = (config: ConfigProps) => {
     return {
       value: 6.0,
       formatted: "6.0%",
+    }
+  }
+  if (config.cellarNameKey === CellarNameKey.TURBO_RSETH) {
+    return {
+      value: 8.0,
+      formatted: "8.0%",
     }
   }
 }


### PR DESCRIPTION
Added estimated APY 8.00%
Kelp Miles instead of Renzo Points

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new calculations and logic for APY (Annual Percentage Yield) specifically for the TURBO_RSETH strategy.
- **Documentation**
	- Updated the strategy description to reflect the shift from "Renzo points" to "Kelp Miles" and the inclusion of EigenLayer in the rewards system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->