### PR TITLE
"Kelp Miles" badge for Turbo rsETH

### DIFF
--- a/src/data/strategies/turbo-rseth.ts
+++ b/src/data/strategies/turbo-rseth.ts
@@ -85,6 +85,12 @@ export const turborsETH: CellarData = {
       abi: config.CONTRACT.TURBO_RSETH_STAKER.ABI,
       key: StakerKey.CELLAR_STAKING_V0821,
     },
+    badges: [
+      {
+        customStrategyHighlight: "Kelp Miles",
+        customStrategyHighlightColor: "#00C04B",
+      },
+    ],
     baseAsset: tokenConfigMap.WETH_ETHEREUM,
   },
 }


### PR DESCRIPTION
Added "Kelp Miles" badge for Turbo rsETH
![Screenshot 2024-03-01 at 16 14 02](https://github.com/PeggyJV/sommelier-strangelove/assets/26877917/2775ef43-9c3c-41ac-a475-b2ce6033080c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Introduced "Kelp Miles" badges in the display, enhancing the visibility of custom strategies within the app.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->