### PR TITLE
Turbo-rsETH badge "EigenLayer Points"; 3x Kelp Miles

### DIFF
--- a/src/data/strategies/turbo-rseth.ts
+++ b/src/data/strategies/turbo-rseth.ts
@@ -87,7 +87,7 @@ export const turborsETH: CellarData = {
     },
     badges: [
       {
-        customStrategyHighlight: "Kelp Miles",
+        customStrategyHighlight: "3x Kelp Miles",
         customStrategyHighlightColor: "#00C04B",
       },
       {


### PR DESCRIPTION

![Screenshot 2024-03-05 at 13 15 43](https://github.com/PeggyJV/sommelier-strangelove/assets/26877917/15d1132e-2966-4b97-961a-22f5312ee906)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced "EigenLayer Points" as a custom strategy highlight for turborsETH, displayed in the color "#00C04B".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->