### PR TITLE
banner

### DIFF
--- a/src/components/_pages/PageHome.tsx
+++ b/src/components/_pages/PageHome.tsx
@@ -293,13 +293,13 @@ export const PageHome = () => {
   const loading = isFetching || isRefetching || isLoading
   return (
     <LayoutWithSidebar>
-      {/* {
+      {
         <InfoBanner
           text={
-            "A new SOMM incentive for Real Yield ETH (Ethereum deployment) is progressing through governance. If it passes, incentives should begin flowing in the next several days."
+            "A new SOMM incentive proposal for Real Yield ETH on Arbitrum is progressing through governance. If it passes, rewards will begin on March 17."
           }
         />
-      } */}
+      }
       {/* <HStack
         p={4}
         mb={6}


### PR DESCRIPTION
Request: Need a banner for RY ETH on Arbitrum. "A new SOMM incentive proposal for Real Yield ETH on Arbitrum is progressing through governance. If it passes, rewards will begin on March 17"

<img width="943" alt="Screenshot 2024-03-14 at 15 51 10" src="https://github.com/PeggyJV/sommelier-strangelove/assets/26877917/05bc05e1-2cd6-4bd2-bfd1-d4a37f9922a6">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Updated the InfoBanner on the homepage with details on the SOMM incentive proposal for Real Yield ETH on Arbitrum, including the start date for rewards.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->