### PR TITLE
RYE-ARB-30D-APY

### DIFF
--- a/src/data/context/apyChartContext.tsx
+++ b/src/data/context/apyChartContext.tsx
@@ -510,8 +510,6 @@ export const ApyChartProvider: FC<{
   // Override time array for Morpho ETH
   if (
     cellarConfig.slug === utilConfig.CONTRACT.MORPHO_ETH.SLUG ||
-    cellarConfig.slug ===
-      utilConfig.CONTRACT.REAL_YIELD_ETH_ARB.SLUG ||
     cellarConfig.slug === utilConfig.CONTRACT.REAL_YIELD_USD_ARB.SLUG
   ) {
     timeArray = [
@@ -527,8 +525,6 @@ export const ApyChartProvider: FC<{
     if (allTimeData && idIsDefault && strategyData) {
       if (
         cellarConfig.slug === utilConfig.CONTRACT.MORPHO_ETH.SLUG ||
-        cellarConfig.slug ===
-          utilConfig.CONTRACT.REAL_YIELD_ETH_ARB.SLUG ||
         cellarConfig.slug ===
           utilConfig.CONTRACT.REAL_YIELD_USD_ARB.SLUG
       ) {

--- a/src/data/strategies/real-yield-eth-arb.ts
+++ b/src/data/strategies/real-yield-eth-arb.ts
@@ -88,7 +88,6 @@ export const realYieldEthArb: CellarData = {
     },
     baseAsset: tokenConfigMap.WETH_ARBITRUM,
     chain: chainSlugMap.ARBITRUM,
-    show7DayAPYTooltip: true,
   },
 
   faq: [

--- a/src/data/uiConfig.ts
+++ b/src/data/uiConfig.ts
@@ -565,7 +565,6 @@ export const apyHoverLabel = (config: ConfigProps) => {
       return "Estimated APY"
     } else if (
       config.cellarNameKey === CellarNameKey.MORPHO_ETH ||
-      config.cellarNameKey === CellarNameKey.REAL_YIELD_ETH_ARB ||
       config.cellarNameKey === CellarNameKey.REAL_YIELD_USD_ARB ||
       config.cellarNameKey === CellarNameKey.TURBO_STETH_STETH_DEPOSIT
     ) {
@@ -595,7 +594,6 @@ export const baseApyHoverLabel = (config: ConfigProps) => {
     return "Estimated APY"
   } else if (
     config.cellarNameKey === CellarNameKey.MORPHO_ETH ||
-    config.cellarNameKey === CellarNameKey.REAL_YIELD_ETH_ARB ||
     config.cellarNameKey === CellarNameKey.REAL_YIELD_USD_ARB ||
     config.cellarNameKey === CellarNameKey.TURBO_STETH_STETH_DEPOSIT
   ) {


### PR DESCRIPTION
Switch RYE-ARB from 7D to 30D-APY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified data retrieval logic in the APY chart by removing specific conditions related to the `REAL_YIELD_ETH_ARB` slug.
	- Updated UI configuration by removing conditions for `REAL_YIELD_ETH_ARB` in hover label functions.
- **Chores**
	- Removed the `show7DayAPYTooltip` feature for the `realYieldEthArb` strategy to streamline user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->