### PR TITLE
Increased the default margin in the gasLimitMargin function to 30%.

### DIFF
--- a/src/utils/estimateGasLimit.ts
+++ b/src/utils/estimateGasLimit.ts
@@ -1,11 +1,12 @@
-import { BigNumber, BigNumberish } from "ethers"
+import { BigNumber, BigNumberish } from "ethers";
 
+// Increase default margin to 30%
 export const gasLimitMargin = (
   gasEstimated: BigNumber,
   margin?: number
 ) =>
   gasEstimated
-    .mul(Number((margin ? margin : 1.1) * 100).toFixed()) // default increase 10%
+    .mul(Number((margin ? margin : 1.3) * 100).toFixed()) // default increase 30%
     .div(100)
 
 export const estimateGasLimit = async (
@@ -22,7 +23,8 @@ export const estimateGasLimit = async (
   }
 }
 
-const PAD = [1.15, 1.3, 1.45, 1.6, 1.75]
+// Increase PAD values to provide larger buffer on retries
+const PAD = [1.25, 1.4, 1.55, 1.7, 1.85]
 
 /**
  *


### PR DESCRIPTION
**Request:** we think the front end might not be estimating gas with enough of a buffer for RYBTC

had a few txs revert because of insufficient gas

**Solution:**
Increased the default margin in the gasLimitMargin function to 30%.
Updated the PAD values to start at 1.25 and go up to 1.85 to provide a larger buffer during retries.
This should ensure that your transactions have a higher chance of success by accounting for the gas used in both successful and failed transactions plus an additional buffer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Increased default margin for gas limit calculation from 10% to 30% for better accuracy.
  - Adjusted buffer values for retries to improve transaction reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->