### PR TITLE
deprecate-turbo-vaults

### DIFF
--- a/src/data/strategies/turbo-diveth.ts
+++ b/src/data/strategies/turbo-diveth.ts
@@ -10,6 +10,7 @@ import { tokenConfigMap } from "src/data/tokenConfig"
 import { chainSlugMap } from "data/chainConfig"
 
 export const turbodivETH: CellarData = {
+  deprecated: true,
   name: "Turbo divETH",
   slug: config.CONTRACT.TURBO_DIVETH.SLUG,
   tradedAssets: ["WETH", "rETH"],

--- a/src/data/strategies/turbo-eethv2.ts
+++ b/src/data/strategies/turbo-eethv2.ts
@@ -11,6 +11,7 @@ import { tokenConfigMap } from "src/data/tokenConfig"
 import { chainSlugMap } from "data/chainConfig"
 
 export const turboeETHV2: CellarData = {
+  deprecated: true,
   name: "Turbo eETH V2",
   slug: config.CONTRACT.TURBO_EETHV2.SLUG,
   tradedAssets: ["WETH", "eETH", "weETH"],

--- a/src/data/strategies/turbo-ethx.ts
+++ b/src/data/strategies/turbo-ethx.ts
@@ -11,6 +11,7 @@ import { tokenConfigMap } from "src/data/tokenConfig"
 import { chainSlugMap } from "data/chainConfig"
 
 export const turboETHx: CellarData = {
+  deprecated: true,
   name: "Turbo ETHx",
   slug: config.CONTRACT.TURBO_ETHX.SLUG,
   tradedAssets: ["ETHx", "WETH"],

--- a/src/data/strategies/turbo-ezeth.ts
+++ b/src/data/strategies/turbo-ezeth.ts
@@ -11,6 +11,7 @@ import { tokenConfigMap } from "src/data/tokenConfig"
 import { chainSlugMap } from "data/chainConfig"
 
 export const turboezETH: CellarData = {
+  deprecated: true,
   name: "Turbo ezETH",
   slug: config.CONTRACT.TURBO_EZETH.SLUG,
   tradedAssets: ["WETH", "ezETH"],

--- a/src/data/strategies/turbo-gho.ts
+++ b/src/data/strategies/turbo-gho.ts
@@ -11,6 +11,7 @@ import { tokenConfigMap } from "src/data/tokenConfig"
 import { chainSlugMap } from "data/chainConfig"
 
 export const turboGHO: CellarData = {
+  deprecated: true,
   name: "Turbo GHO",
   slug: config.CONTRACT.TURBO_GHO.SLUG,
   tradedAssets: ["GHO", "USDC", "USDT", "LUSD"],

--- a/src/data/strategies/turbo-rseth.ts
+++ b/src/data/strategies/turbo-rseth.ts
@@ -11,6 +11,7 @@ import { tokenConfigMap } from "src/data/tokenConfig"
 import { chainSlugMap } from "data/chainConfig"
 
 export const turborsETH: CellarData = {
+  deprecated: true,
   name: "Turbo rsETH",
   slug: config.CONTRACT.TURBO_RSETH.SLUG,
   tradedAssets: ["WETH", "rsETH"],

--- a/src/data/strategies/turbo-somm.ts
+++ b/src/data/strategies/turbo-somm.ts
@@ -10,6 +10,7 @@ import { tokenConfigMap } from "src/data/tokenConfig"
 import { chainSlugMap } from "data/chainConfig"
 
 export const turboSOMM: CellarData = {
+  deprecated: true,
   name: "Turbo SOMM",
   slug: config.CONTRACT.TURBO_SOMM.SLUG,
   tradedAssets: ["SOMM", "WETH"],

--- a/src/data/strategies/turbo-sweth.ts
+++ b/src/data/strategies/turbo-sweth.ts
@@ -12,6 +12,7 @@ import { tokenConfigMap } from "src/data/tokenConfig"
 import { chainSlugMap } from "data/chainConfig"
 
 export const turboSWETH: CellarData = {
+  deprecated: true,
   name: "Turbo swETH",
   slug: config.CONTRACT.TURBO_SWETH.SLUG,
   tradedAssets: ["swETH", "WETH"],


### PR DESCRIPTION
Fixes #<ISSUE_NUMBER>

## Description

Describe big picture changes here. This will give viewers context for the changes.

## Changes

List any technical changes.

- [ ] Change 1

## Screenshots (if appropriate):

## Testing Steps

As a reviewer, what steps should I take to verify this is working correctly?

- [ ] Step 1

## Links

Add links to Figma files, documentation, etc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Marked multiple strategies as deprecated, indicating they are no longer recommended for use. This includes:
		- turbodivETH
		- turboeETHV2
		- turboETHx
		- turboezETH
		- turboGHO
		- turborsETH
		- turboSOMM
		- turboSWETH

These updates help users identify strategies that should not be utilized in current operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->