### PR TITLE
cbETH-adr

### DIFF
--- a/src/data/tokenConfig.ts
+++ b/src/data/tokenConfig.ts
@@ -253,7 +253,7 @@ export const tokenConfig: Token[] = [
     src: "/assets/icons/cbETH.png",
     alt: "cbETH logo",
     symbol: "cbETH",
-    address: "00xadDb6A0412DE1BA0F936DCaeb8Aaa24578dcF3B2",
+    address: "0xadDb6A0412DE1BA0F936DCaeb8Aaa24578dcF3B2",
     coinGeckoId: "coinbase-wrapped-staked-eth",
     decimals: 18,
     chain: chainSlugMap.OPTIMISM.id,


### PR DESCRIPTION
The address for cbETH on the Optimism chain contains a typo with an extra leading zero. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the Ethereum address format for the `cbETH` token under the `OPTIMISM` chain, ensuring proper functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->