### PR TITLE
UX/withdraw: Alpha stETH preflight stabilization, clear messages, and wstETH-only asset out

### DIFF
--- a/src/components/_menus/ModalMenu/OnlyTokenMenu.tsx
+++ b/src/components/_menus/ModalMenu/OnlyTokenMenu.tsx
@@ -10,7 +10,7 @@ import {
   MenuOptionGroup,
   Text,
 } from "@chakra-ui/react"
-import { useRef } from "react"
+import { useEffect, useRef } from "react"
 import { FaChevronDown } from "react-icons/fa"
 import { getTokenConfig, Token } from "data/tokenConfig"
 import { useFormContext } from "react-hook-form"
@@ -52,6 +52,17 @@ export const OnlyTokenMenu = ({
     depositTokens,
     cellarConfig.chain.id
   ) as Token[]
+
+  // Avoid setState during render: set default selected token once when ready
+  useEffect(() => {
+    if (!value && activeAsset) {
+      const def = depositTokenConfig.find(
+        (t) => t.address.toUpperCase() === activeAsset.toUpperCase()
+      )
+      if (def) onChange(def)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, activeAsset, depositTokenConfig])
 
   return (
     <HStack
@@ -114,9 +125,6 @@ export const OnlyTokenMenu = ({
               const isActiveAsset =
                 token.address.toUpperCase() ===
                 activeAsset?.toUpperCase()
-
-              // Set default selected token to active asset.
-              if (isActiveAsset && !value) onChange(token)
 
               return (
                 <MenuItemOption


### PR DESCRIPTION
### TL;DR
- Fixes Alpha stETH (GGV) Withdraw modal gating: no more indefinite "Calculating…" and no vague "not available".
- Uses paid RPC (Alchemy → Infura) for all reads/simulations; no public RPC.
- Hides stETH in Asset Out for Alpha stETH; prefers wstETH to avoid discount invalids.
- Adds dust guard ("Amount too small to withdraw.") and precise error taxonomy (TIMEOUT / DISCOUNT / REVERT).

### Context
Wallet: 0xC3B356C5E0dA0355560c8f2E4189Fb1c5d2981Cd
Vault (GG shares): 0xef417FCE1883c6653E7dC6AF7c6F85CCDE84Aa09
Queue (BoringOnChainQueue): 0xe39682c3C44b73285A2556D4869041e674d1a6B7

### Changes
- Withdraw Queue form (UI only):
  - Preflight resiliency: debounce + keyed state + 6s timeout + single retry + stale-key guard + Retry link
  - Dust guard using previewAssetsOut; shows "Amount too small to withdraw."
  - Alpha stETH: default/hide stETH; Asset Out shows only wstETH
  - Clear messages mapping: 
    - Validating → "Validating withdrawal…"
    - Timeout → "Preflight took too long. Please retry."
    - Discount invalid → "stETH withdrawal requires a 1–10% discount."
    - Generic revert → "This withdrawal cannot be simulated. Check your input."
- List CTA: enable Withdraw when user has LP shares (not only netValue)
- Provider usage: paid RPC (Alchemy → Infura) only for on-chain reads/sims

### Flow Map (Alpha stETH)
0) Network/connection guards → OK
1) Shares check → UI shows LP shares
2) Allowance check → prompts if required
3) AssetOut selection → wstETH only (Alpha stETH)
4) Preflight simulate → sets isRequestValid (no infinite spinners)
5) Submit → requestOnChainWithdraw or replaceOnChainWithdraw
6) Pending request → replace path surfaced via banner

### Ruled out
- Public RPCs (not used)
- wstETH asset disabled (allowed)
- List CTA disabled due to zero shares (fixed gating)

### Suspects previously causing stalls
- stETH discount invalids when stETH selected
- Very small shares (dust) previewing to zero and being treated as timeout
- Render-time setState causing effect loops (now guarded)

### Next steps (if needed)
- If product wants stETH option visible, auto-clamp discount to 1–10% on simulate/submit.
- Add dev-only gate logger if more visibility is needed (reasons Submit is disabled).

