### PR TITLE
chore(ci): restore minimal GitHub Actions and align with Vercel previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,116 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  NEXT_TELEMETRY_DISABLED: "1"
+  CI: "true"
+  NEXT_PUBLIC_ANALYTICS_ENABLED: "false"
+  NEXT_PUBLIC_ATTRIBUTION_ENABLED: "false"
+  EVENTS_SALT: "ci-default-salt"
+  KV_REST_API_URL: "https://example.upstash.io"
+  KV_REST_API_TOKEN: "ci-dummy-token"
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+      - name: ESLint (CI)
+        run: pnpm run lint:ci
+      - name: Upload ESLint JUnit
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eslint-junit.xml
+          path: reports/eslint-junit.xml
+          if-no-files-found: ignore
+
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+      - name: TypeScript typecheck
+        run: pnpm run typecheck
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+      - name: Jest (coverage)
+        run: pnpm run test:ci
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage
+          if-no-files-found: ignore
+
+  build:
+    name: build
+    needs: [lint, typecheck, test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+      - name: Cache Next.js
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: next-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            next-${{ runner.os }}-
+      - name: Next build
+        run: pnpm run build
+
+


### PR DESCRIPTION
## What
- Add `.github/workflows/ci.yml` with 4 parallel jobs: `lint`, `typecheck`, `test`, `build` (Node 22, pnpm cache).
- No deployments from Actions; Vercel GitHub App continues to handle Preview + Production deploys.
- Safe default envs in CI to avoid build-time client instantiation failures.

## CI job names (for branch protection)
- ci / lint
- ci / typecheck
- ci / test
- ci / build

## Vercel settings (apply once)
- Project: sommelier-web
- Production Branch: `main`
- Deploy Previews: Enabled for PRs
- Env — Preview: `NEXT_PUBLIC_ANALYTICS_ENABLED`, `NEXT_PUBLIC_ATTRIBUTION_ENABLED`, `EVENTS_SALT`, `KV_REST_API_URL`, `KV_REST_API_TOKEN`
- Env — Production: same with prod values
- Build: `pnpm install` → `pnpm run build`; Output: `.next`

## Legacy workflows to disable in this PR (keep new `ci` only)
- Remove/disable legacy checks so the surface is clean:
  - "Performance Validation / performance"
  - "Tests / unit_integration"
  - Any legacy "Tests / e2e" workflow
- Easiest: delete their YAMLs under `.github/workflows/`, or change triggers to only `on: workflow_dispatch`.
- Do NOT remove the new `ci` jobs (`lint`, `typecheck`, `test`, `build`). They may fail initially due to code issues; we will fix those in follow-ups.

## Branch protection (main)
Require status checks:
- ci / lint
- ci / typecheck
- ci / test
- ci / build
- Vercel — Preview Ready (GitHub App status)
Also: 1 review; require branch up-to-date.

## Deploy flow
- PR → Actions (lint/typecheck/test/build) + Vercel Preview "Ready" → merge to `main` → Vercel auto-deploys Production.

## Secrets
- None required (Vercel GitHub App deploys).
- Optional if we later deploy from Actions: `VERCEL_TOKEN` (+ `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`).'