### PR TITLE
chore(tg): enable daily Alpha stETH Telegram posting

### DIFF
--- a/.github/workflows/alpha-steth-deposits.yml
+++ b/.github/workflows/alpha-steth-deposits.yml
@@ -13,7 +13,13 @@ jobs:
   report:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+    env:
+      REPORT_API_BASE: ${{ secrets.REPORT_API_BASE }}
+      START_BLOCK_ALPHA_STETH: ${{ secrets.START_BLOCK_ALPHA_STETH }}
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+      TELEGRAM_MODE: "strict"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,11 +37,9 @@ jobs:
 
       - name: Validate production data
         env:
-          REPORT_API_BASE: ${{ secrets.REPORT_API_BASE }}
           KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
           KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
           NEXT_PUBLIC_ATTRIBUTION_ENABLED: "true"
-          START_BLOCK_ALPHA_STETH: ${{ secrets.START_BLOCK_ALPHA_STETH }}
           ALLOWED_API_HOSTS: ".somm.finance,.sommelier.finance"
         run: |
           echo "Validating production data source..."
@@ -50,24 +54,8 @@ jobs:
           path: docs/analytics/validation-fail.md
           retention-days: 30
 
-      - name: Generate deposits report (no Telegram)
+      - name: Generate deposits report & post to Telegram
         if: success()
-        env:
-          REPORT_API_BASE: ${{ secrets.REPORT_API_BASE }}
-          START_BLOCK_ALPHA_STETH: ${{ secrets.START_BLOCK_ALPHA_STETH }}
-          # TELEGRAM_MODE not set - will disable Telegram posting
         run: |
-          echo "Validation passed. Generating report (Telegram disabled)..."
-          node scripts/analytics/generate-alpha-deposits.mjs
-
-      - name: Commit artifacts
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git diff --cached --quiet || git commit -m "chore(analytics): update Alpha stETH deposits report"
-
-      - name: Push
-        if: ${{ success() }}
-        run: |
-          git push
+          echo "Validation passed. Exporting and posting to Telegram..."
+          node scripts/analytics/export-alpha-deposits.mjs --post-telegram

--- a/.github/workflows/alpha-steth-export.yml
+++ b/.github/workflows/alpha-steth-export.yml
@@ -52,9 +52,10 @@ jobs:
             docs/analytics/alpha-steth-deposits.md
           retention-days: 30
 
-      # Optional: uncomment to post to Telegram too
-      # - name: Post to Telegram
-      #   run: pnpm export:alpha:tg
+      - name: Post to Telegram
+        env:
+          TELEGRAM_MODE: "strict"
+        run: pnpm export:alpha:tg
 
       - name: Commit artifacts
         run: |


### PR DESCRIPTION
- Switch daily workflow to call export-alpha-deposits.mjs with --post-telegram\n- Use TELEGRAM_MODE=strict; requires repo secrets set (TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID, START_BLOCK_ALPHA_STETH, REPORT_API_BASE, KV_REST_API_URL, KV_REST_API_TOKEN)\n- Remove commit/push of artifacts; TG post only\n- Keeps manual workflow (alpha-steth-export.yml) for ad-hoc runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Alpha stETH workflows now automatically post reports to Telegram; Telegram mode set to “strict”.
  * Consolidated report generation into a single export-and-post step; removed separate artifact commit/push steps.
  * Standardized environment variables at the job level for consistent configuration.
  * Reduced repository content permissions from write to read for improved security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->