### PR TITLE
Redirect Alpha stETH withdraw flow to Lido GGV

### DIFF
--- a/src/components/_buttons/DepositAndWithdrawButton.tsx
+++ b/src/components/_buttons/DepositAndWithdrawButton.tsx
@@ -251,6 +251,17 @@ export function DepositAndWithdrawButton({
               e.stopPropagation()
               // analytics.track("home.deposit.modal-opened")
 
+              // Alpha stETH has been replaced by Lido GGV — send users
+              // there to upgrade their position instead of withdrawing.
+              if (id === "Alpha-stETH") {
+                window.open(
+                  "https://stake.lido.fi/earn/ggv/deposit",
+                  "_blank",
+                  "noopener,noreferrer"
+                )
+                return
+              }
+
               // Check if user is on the right chain, if not prompt them to switch
               if (
                 cellarConfig &&

--- a/src/components/_cards/PortfolioCard/index.tsx
+++ b/src/components/_cards/PortfolioCard/index.tsx
@@ -544,7 +544,34 @@ export const PortfolioCard = (props: BoxProps) => {
                           width="100%"
                           minW={0}
                         >
-                          {isWithdrawQueueEnabled(cellarConfig) ? (
+                          {isAlphaSteth ? (
+                            <Button
+                              as="a"
+                              href="https://stake.lido.fi/earn/ggv/deposit"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              size={{ base: "sm", md: "md" }}
+                              height={{ base: "40px", md: "44px" }}
+                              variant="outline"
+                              bg="transparent"
+                              color="cta.outline.fg"
+                              borderColor="cta.outline.br"
+                              borderWidth="2px"
+                              width={{ base: "100%", md: "100%" }}
+                              rightIcon={<FaExternalLinkAlt />}
+                              sx={{
+                                whiteSpace: "nowrap",
+                                textOverflow: "ellipsis",
+                                overflow: "hidden",
+                              }}
+                              _focusVisible={{
+                                boxShadow:
+                                  "0 0 0 3px var(--chakra-colors-purple-base)",
+                              }}
+                            >
+                              Upgrade on Lido GGV
+                            </Button>
+                          ) : isWithdrawQueueEnabled(cellarConfig) ? (
                             <WithdrawQueueButton
                               chain={cellarConfig.chain}
                               buttonLabel={withdrawQueueLabel}

--- a/src/components/_pages/PageCellar.tsx
+++ b/src/components/_pages/PageCellar.tsx
@@ -109,6 +109,34 @@ const PageCellar: FC<PageCellarProps> = ({ id }) => {
   return (
     <Layout chainObj={cellarConfig.chain}>
       <WalletHealthBanner />
+      {isAlphaSteth && (
+        <InfoBanner
+          text={
+            <>
+              Alpha stETH has been succeeded by{" "}
+              <a
+                href="https://stake.lido.fi/earn/eth/deposit"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ textDecoration: "underline" }}
+              >
+                Lido Earn ETH
+              </a>
+              . Existing depositors can upgrade to the new vault or
+              withdraw via{" "}
+              <a
+                href="https://stake.lido.fi/earn/ggv/deposit"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ textDecoration: "underline" }}
+              >
+                Lido GGV
+              </a>
+              .
+            </>
+          }
+        />
+      )}
       {cellarConfig.cellarNameKey === CellarNameKey.TURBO_EETH && (
         <InfoBanner
           text={


### PR DESCRIPTION
## Summary
- Alpha stETH has been succeeded by Lido Earn ETH; users upgrade or withdraw via Lido GGV
- Replace the Alpha stETH withdraw CTAs (PortfolioCard + strategies-table) with an external link to https://stake.lido.fi/earn/ggv/deposit
- Add an InfoBanner on the Alpha stETH page pointing to Earn ETH (successor) and GGV (action surface)

## Test plan
- [ ] Navigate to Alpha stETH page: banner shows with both links
- [ ] Connected wallet with Alpha stETH balance: portfolio card shows "Upgrade on Lido GGV" instead of "Enter Withdraw Queue"; clicking opens Lido GGV in new tab
- [ ] Home strategies table: clicking the Alpha stETH withdraw button opens Lido GGV in new tab (no withdraw modal)
- [ ] Other vaults (RYE, Turbo stETH, Turbo eETH, etc.) retain their existing withdraw flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change scoped to the `Alpha-stETH` strategy that replaces an internal withdraw flow with an external link; main risk is misrouting users if the slug/URL is wrong.
> 
> **Overview**
> Updates the `Alpha-stETH` user flows to **stop opening the in-app withdraw/queue experience** and instead send users to Lido’s external upgrade surface (`https://stake.lido.fi/earn/ggv/deposit`) from both the home strategies table withdraw button and the portfolio card CTA.
> 
> Adds an `InfoBanner` on the Alpha stETH strategy page linking to **Lido Earn ETH** as the successor and **Lido GGV** as the upgrade/withdraw path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9687b34e677bf925e9af14b66240d2e1fd231b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alpha-stETH strategy now routes users to an external Lido GGV deposit interface for transactions
  * Added informational banner for Alpha-stETH users with links for upgrading positions and managing withdrawals

<!-- end of auto-generated comment: release notes by coderabbit.ai -->