### PR TITLE
TurboSTETH: enable direct withdrawals with live liquidity status

### DIFF
--- a/src/components/_forms/WithdrawForm.tsx
+++ b/src/components/_forms/WithdrawForm.tsx
@@ -46,6 +46,7 @@ import {
   type TransactionErrorContext,
 } from "utils/handleTransactionError"
 import { config } from "utils/config"
+import { isWithdrawQueueEnabled } from "data/uiConfig"
 
 interface FormValues {
   withdrawAmount: number
@@ -144,9 +145,51 @@ export const WithdrawForm = ({ onClose }: WithdrawFormProps) => {
       cellarConfig.cellar.decimals
     )
 
+    const liquidityPreflightSlugs = new Set<string>([
+      config.CONTRACT.ALPHA_STETH.SLUG,
+      config.CONTRACT.TURBO_STETH.SLUG,
+    ])
+
+    const handleInsufficientLiquidity = (
+      redeemableAssets: number,
+      previewRedeem: number
+    ) => {
+      // Queue is the primary path only for vaults explicitly configured
+      // to use it (e.g. AlphaSTETH). For every other vault, surface
+      // the liquidity shortfall directly instead of pushing the queue.
+      if (isWithdrawQueueEnabled(cellarConfig)) {
+        openWithdrawQueueModal()
+        return
+      }
+      const decimals = cellarConfig.cellar.decimals
+      const maxShares =
+        previewRedeem > 0
+          ? (redeemableAssets / previewRedeem).toFixed(
+              Math.min(decimals, 6)
+            )
+          : "0"
+      addToast({
+        heading: "Insufficient vault liquidity",
+        body: (
+          <Text>
+            The vault doesn&apos;t currently hold enough liquid assets
+            to process this redemption. Maximum currently
+            withdrawable: {maxShares}{" "}
+            {lpTokenData?.symbol ?? "shares"}. Please reduce your
+            amount and try again.
+          </Text>
+        ),
+        status: "default",
+        closeHandler: closeAll,
+      })
+      setValue("withdrawAmount", 0)
+      refetch()
+    }
+
     try {
-      // Alpha STETH: pre-check redeemable liquidity to avoid failing redeem tx
-      if (id === config.CONTRACT.ALPHA_STETH.SLUG) {
+      // Pre-check redeemable liquidity for cellars where the strategist
+      // may park assets in non-synchronously-liquid positions
+      if (liquidityPreflightSlugs.has(id)) {
         const redeemableAssets: number = parseInt(
           await fetchCellarRedeemableReserves(id)
         )
@@ -160,7 +203,7 @@ export const WithdrawForm = ({ onClose }: WithdrawFormProps) => {
           previewRedeem * watchWithdrawAmount
         )
         if (redeemAmt > redeemableAssets) {
-          openWithdrawQueueModal()
+          handleInsufficientLiquidity(redeemableAssets, previewRedeem)
           return
         }
       }
@@ -233,8 +276,7 @@ export const WithdrawForm = ({ onClose }: WithdrawFormProps) => {
 
       // Check if attempting to withdraw more than availible
       if (redeemingMoreThanAvailible) {
-        // Open a modal with information about the withdraw queue
-        openWithdrawQueueModal()
+        handleInsufficientLiquidity(redeemableAssets, previewRedeem)
       } else {
         // Use centralized error handling
         const errorContext: TransactionErrorContext = {

--- a/src/components/_sections/WithdrawalWarningBanner.tsx
+++ b/src/components/_sections/WithdrawalWarningBanner.tsx
@@ -8,7 +8,11 @@ import {
   ListItem,
   Icon,
   IconProps,
+  Spinner,
 } from "@chakra-ui/react"
+import { useQuery } from "@tanstack/react-query"
+import { config as utilConfig } from "utils/config"
+import { fetchCellarLiquidityState } from "queries/get-cellar-liquidity-state"
 
 function WarningIcon(props: IconProps) {
   return (
@@ -16,6 +20,63 @@ function WarningIcon(props: IconProps) {
       <path fill="currentColor" d="M1 21h22L12 2 1 21z" />
       <path fill="currentColor" d="M13 16h-2v2h2zm0-6h-2v4h2z" />
     </Icon>
+  )
+}
+
+function TurboStethStatus() {
+  const slug = utilConfig.CONTRACT.TURBO_STETH.SLUG
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["cellar-liquidity-state", slug],
+    queryFn: () => fetchCellarLiquidityState(slug),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  })
+
+  if (isLoading) {
+    return (
+      <HStack spacing={2}>
+        <Spinner size="xs" />
+        <Text>Checking TurboStETH liquidity…</Text>
+      </HStack>
+    )
+  }
+
+  if (isError || !data || data.totalAssets === 0n) {
+    return (
+      <Text>
+        <Text as="span" fontWeight="semibold" color="yellow.300">
+          TurboStETH
+        </Text>{" "}
+        – Withdrawals are open. The withdrawal form will tell you the
+        maximum amount currently available.
+      </Text>
+    )
+  }
+
+  const liquidPct =
+    Number((data.totalAssetsWithdrawable * 10000n) / data.totalAssets) /
+    100
+
+  if (liquidPct >= 99.5) {
+    return (
+      <Text>
+        <Text as="span" fontWeight="semibold" color="green.300">
+          TurboStETH
+        </Text>{" "}
+        – Fully liquid. Withdraw directly from the vault.
+      </Text>
+    )
+  }
+
+  return (
+    <Text>
+      <Text as="span" fontWeight="semibold" color="green.300">
+        TurboStETH
+      </Text>{" "}
+      – {liquidPct.toFixed(0)}% of NAV is currently liquid and
+      available for direct withdrawal. Larger redemptions will need to
+      wait for the strategist to rebalance liquidity.
+    </Text>
   )
 }
 
@@ -57,12 +118,7 @@ export default function WithdrawalWarningBanner() {
           </Text>
         </ListItem>
         <ListItem>
-          <Text>
-            <Text as="span" fontWeight="semibold" color="yellow.300">
-              TurboStETH
-            </Text>{" "}
-            – Please enter the withdrawal queue.
-          </Text>
+          <TurboStethStatus />
         </ListItem>
         <ListItem>
           <Text>

--- a/src/pages/api/cellar-liquidity-state.ts
+++ b/src/pages/api/cellar-liquidity-state.ts
@@ -1,0 +1,65 @@
+import { NextApiRequest, NextApiResponse } from "next"
+import { cellarDataMap } from "data/cellarDataMap"
+import { queryContract } from "context/rpc_context"
+
+const baseUrl =
+  process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"
+
+type LiquidityStateContract = {
+  read: {
+    totalAssets: () => Promise<bigint | string>
+    totalAssetsWithdrawable: () => Promise<bigint | string>
+  }
+}
+
+const cellarLiquidityState = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+) => {
+  try {
+    let { cellarId } = req.query
+    cellarId = cellarId as string
+
+    if (!cellarId || !cellarDataMap[cellarId]) {
+      res.status(400).send({
+        error: "missing or unknown cellar id",
+        message: "missing or unknown cellar id",
+      })
+      return
+    }
+
+    const cellar = (await queryContract(
+      cellarDataMap[cellarId].config.id,
+      cellarDataMap[cellarId].config.cellar.abi,
+      cellarDataMap[cellarId].config.chain
+    )) as LiquidityStateContract | null
+
+    if (!cellar) {
+      throw new Error("failed to load contract")
+    }
+
+    const [totalAssets, totalAssetsWithdrawable] = await Promise.all([
+      cellar.read.totalAssets(),
+      cellar.read.totalAssetsWithdrawable(),
+    ])
+
+    res.setHeader(
+      "Cache-Control",
+      "public, maxage=60, s-maxage=60, stale-while-revalidate=120"
+    )
+    res.setHeader("Access-Control-Allow-Origin", baseUrl)
+    res.status(200).json({
+      totalAssets: String(totalAssets),
+      totalAssetsWithdrawable: String(totalAssetsWithdrawable),
+    })
+  } catch (error) {
+    console.error(error)
+    res.status(500).send({
+      error: "failed to fetch data",
+      message:
+        (error as Error).message || "An unknown error occurred",
+    })
+  }
+}
+
+export default cellarLiquidityState

--- a/src/queries/get-cellar-liquidity-state.ts
+++ b/src/queries/get-cellar-liquidity-state.ts
@@ -1,0 +1,24 @@
+export type CellarLiquidityState = {
+  totalAssets: bigint
+  totalAssetsWithdrawable: bigint
+}
+
+const getUrl = (cellarId: string) =>
+  `/api/cellar-liquidity-state?cellarId=${cellarId}`
+
+export const fetchCellarLiquidityState = async (
+  cellarId: string
+): Promise<CellarLiquidityState> => {
+  const res = await fetch(getUrl(cellarId))
+  if (!res.ok) {
+    throw new Error(`Failed to fetch liquidity state: ${res.status}`)
+  }
+  const json = (await res.json()) as {
+    totalAssets: string
+    totalAssetsWithdrawable: string
+  }
+  return {
+    totalAssets: BigInt(json.totalAssets),
+    totalAssetsWithdrawable: BigInt(json.totalAssetsWithdrawable),
+  }
+}


### PR DESCRIPTION
## Summary

- The TurboSTETH cellar has been deleveraged on-chain (no Aave/Morpho debt; `totalAssetsWithdrawable` ≈ 78% of `totalAssets` at time of writing). Direct ERC4626 `redeem` works for the bulk of share supply, so we should stop unconditionally routing users to the withdrawal queue.
- Banner now reflects live on-chain liquidity for TurboSTETH (fully liquid / partially liquid) and never mentions the queue.
- `WithdrawForm` insufficient-liquidity handling now distinguishes queue-native vaults (AlphaSTETH) from everything else: AlphaSTETH still opens the queue modal; TurboSTETH and other non-queue vaults get a clear toast naming the maximum amount currently withdrawable.

## Changes

- **New** `src/pages/api/cellar-liquidity-state.ts` — returns `{ totalAssets, totalAssetsWithdrawable }` for any cellar, mirroring the existing `cellar-redeemable-reserves` / `cellar-preview-redeem` endpoints (60s cache, same `queryContract` plumbing).
- **New** `src/queries/get-cellar-liquidity-state.ts` — typed fetcher returning `bigint`s.
- **Modified** `src/components/_sections/WithdrawalWarningBanner.tsx` — TurboSTETH list item is now a small `TurboStethStatus` subcomponent that reads liquidity via react-query and renders one of: fully liquid, N% liquid, or a conservative fallback. Queue language removed.
- **Modified** `src/components/_forms/WithdrawForm.tsx` — extended the existing AlphaSTETH liquidity preflight to also cover TurboSTETH. Added `handleInsufficientLiquidity()` helper that opens the queue modal only for vaults where `isWithdrawQueueEnabled` is true, and otherwise toasts the user with the current maximum withdrawable amount and resets the form. Both the preflight and the post-failure recovery now use this helper.

## Behavioural effect

At current chain state (42.07 / 53.70 WETH liquid):
- Banner renders "78% of NAV is currently liquid and available for direct withdrawal."
- Most redemptions sign and complete a direct `redeem` with no queue interaction.
- A redemption exceeding the liquid buffer is intercepted before signing and the user sees an actionable toast with the current cap; AlphaSTETH continues to use its existing queue modal.

## Test plan

- [ ] On the legacy vaults section of the home page, confirm the banner shows live TurboSTETH status (green liquidity message) once the API call resolves.
- [ ] On the TurboSTETH page, withdraw a small amount (≤ ~36 shares at current state) and confirm the direct redeem succeeds without prompting the queue.
- [ ] Withdraw an amount larger than the liquid buffer and confirm the toast appears with the correct max-shares figure and no queue modal.
- [ ] On the AlphaSTETH page, confirm the queue modal still opens for over-cap redemptions (regression check).
- [ ] Inspect `/api/cellar-liquidity-state?cellarId=Turbo-stETH` and confirm both fields return numeric strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes withdrawal UX/flow and adds a new API route used to gate redemptions based on on-chain liquidity; mistakes could incorrectly block withdrawals or mislead users about available liquidity.
> 
> **Overview**
> Enables **direct withdrawals for TurboStETH** by replacing the prior queue-first behavior with *liquidity-aware* handling.
> 
> `WithdrawForm` now preflights liquidity for both `AlphaStETH` and `TurboStETH`, and centralizes insufficient-liquidity behavior: queue-enabled vaults still open the queue modal, while other vaults show a toast with the computed maximum withdrawable amount and reset/refetch.
> 
> Adds a new `/api/cellar-liquidity-state` endpoint plus `fetchCellarLiquidityState` query helper, and updates `WithdrawalWarningBanner` to display a live TurboStETH liquidity status (loading, fully liquid, or % liquid) instead of instructing users to use the queue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8726fa8dcf44e3e02268f6f59f372ebe9b25fb29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->