### PR TITLE
new-vaults: fall back to live /tvl when aggregator TVL is missing/zero

### DIFF
--- a/src/pages/api/new-vaults.ts
+++ b/src/pages/api/new-vaults.ts
@@ -37,12 +37,40 @@ type CellarMapEntry = {
 // Temporary list of Somm-native slugs. Extend as more in-house vaults are added.
 const SOMM_NATIVE_SLUGS = new Set<string>(["Alpha-stETH"])
 
+// Live TVL endpoint, used as a fallback when a vault is missing from the
+// aggregator. The aggregator only includes cellars present in the last month
+// of dailyData, so a vault whose data collection has stalled drops out and its
+// TVL would otherwise default to 0 even while it holds real value.
+const LIVE_TVL_URL = "https://api.sommelier.finance/tvl"
+
+// Fetch live per-cellar TVL keyed lowercase (keys are `address` on ethereum or
+// `address-<chain>` on L2s). Never throws -- returns {} on any failure.
+async function fetchLiveTvlByKey(): Promise<Record<string, number>> {
+  try {
+    const res = await fetch(LIVE_TVL_URL)
+    if (!res.ok) return {}
+    const json = await res.json()
+    const resp = (json?.Response ?? {}) as Record<string, unknown>
+    const out: Record<string, number> = {}
+    for (const [k, v] of Object.entries(resp)) {
+      if (k === "total_tvl") continue
+      out[k.toLowerCase()] = Number(v) || 0
+    }
+    return out
+  } catch {
+    return {}
+  }
+}
+
 export default async function handler(
   _req: NextApiRequest,
   res: NextApiResponse
 ) {
   try {
-    const agg = (await fetchCellarStrategyData()) as AggregatedResponse
+    const [agg, liveTvlByKey] = await Promise.all([
+      fetchCellarStrategyData() as Promise<AggregatedResponse>,
+      fetchLiveTvlByKey(),
+    ])
 
     // Map address->tvl from aggregator result (normalize keys to lowercase)
     const tvlByKey: Record<string, number> = {}
@@ -63,7 +91,10 @@ export default async function handler(
       if (!chainId || !addr || !data?.name) continue
       const tvlKey =
         chainId === "ethereum" ? addr : `${addr}-${chainId}`
-      const tvlVal = tvlByKey[tvlKey] ?? 0
+      // Prefer the aggregator value; fall back to live /tvl when the vault is
+      // missing or zero there (e.g. its dailyData feed has stalled).
+      const aggTvl = tvlByKey[tvlKey] ?? 0
+      const tvlVal = aggTvl > 0 ? aggTvl : liveTvlByKey[tvlKey] ?? 0
 
       const tvl = {
         value: tvlVal,


### PR DESCRIPTION
## Symptom

Alpha STETH shows **0 TVL** on app.somm.finance even though live `api.sommelier.finance/tvl` reports ~\$8.6M for it. Confirmed the API returns `{"tvl":{"value":0}}` from `/api/new-vaults`.

## Root cause

`/api/new-vaults` gets TVL from the aggregator (`/api/sommelier-api-all-strategies-data`), which builds its cellar list from `dailyData/ethereum/allCellars/<one-month-ago>/latest` and only attaches `/tvl` values to cellars present in that window. Alpha STETH's backend data collection stalled on 2026-05-06, so it fell outside the one-month window, dropped out of the aggregator, and its TVL defaulted to `0` (`tvlByKey[tvlKey] ?? 0`).

The backend cause (a crashing dataloader) is fixed separately in PeggyJV/somm-api#44. **This PR makes the frontend resilient** so a stalled feed no longer silently renders \$0.

## Fix

Fetch live `/tvl` in parallel with the aggregator and use it as a fallback when the aggregator value is missing or zero:

- `fetchLiveTvlByKey()` — fetches `/tvl`, returns a lowercase-keyed map, **never throws** (returns `{}` on any failure).
- Runs via `Promise.all`, so no added latency in the happy path.
- `tvlVal = aggTvl > 0 ? aggTvl : (liveTvlByKey[tvlKey] ?? 0)`.

## Verification

- Logic verified against the live `/tvl` response (Alpha STETH key `0xef417…` → ~\$8.6M).
- Type-safe by inspection; relies on the same global `fetch` already used in the sibling `sommelier-api-all-strategies-data` route. CI `typecheck`/`lint` will confirm.
- `node_modules` not installed locally (pnpm repo), so local typecheck was skipped in favor of CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, defensive change to TVL display logic with fail-safe empty fallback; no auth or fund-movement paths touched.
> 
> **Overview**
> **`/api/new-vaults`** no longer shows **$0 TVL** when a Somm-native vault drops out of the strategies aggregator (e.g. stalled `dailyData`).
> 
> The handler now loads aggregator data and **`https://api.sommelier.finance/tvl` in parallel** via `Promise.all`. A new **`fetchLiveTvlByKey()`** builds a lowercase address-keyed map from the live response and **never throws** (returns `{}` on failure).
> 
> Per vault, TVL **still prefers the aggregator** when `aggTvl > 0`; otherwise it uses the live `/tvl` value for the same `tvlKey` (`address` on Ethereum, `address-<chain>` on L2s).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56e057524c09fea95df2c1fef96c574c58e62143. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vault TVL (Total Value Locked) data retrieval now implements a robust fallback mechanism that automatically fetches live data when primary aggregated information is unavailable or reports zero values, ensuring reliable and current vault metrics at all times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->