### PR TITLE
ci: fix jest invocation so unit_integration runs the test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,11 @@ jobs:
           name: eslint-junit
           path: reports/eslint-junit.xml
       - name: Test with coverage
-        run: pnpm run test:all -- --coverage
+        # `test:all` already runs `jest --coverage --verbose`. The previous
+        # `-- --coverage` was passed through to jest as a positional test-path
+        # pattern, so jest matched 0 tests and exited 1 ("No tests found"),
+        # failing this job on every run regardless of the actual tests.
+        run: pnpm run test:all
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Problem

The **Tests / unit_integration** job has failed on every push and PR since at least Feb 2026 (`main` and all branches red). The "Test with coverage" step runs:

```
pnpm run test:all -- --coverage
```

`test:all` is already `jest --config jest.json --coverage --verbose`, so the extra `-- --coverage` is forwarded to jest as a **positional test-path pattern**. jest matches 0 files and exits 1:

```
Pattern: --coverage - 0 matches
No tests found, exiting with code 1
```

So the job never actually ran the suite — it just failed on the bad argument.

## Fix

Drop the redundant `-- --coverage`; `test:all` already enables coverage.

## Caveat — surfacing vs. masking

This makes jest actually run the suite. If there are real test failures that have been hidden behind "No tests found" for months, this job may now fail for genuine reasons — that's the correct behavior (surface them) and a strictly better state than a meaningless red. **This PR's own CI run is the real verification** of where the suite stands. (Couldn't run the full suite locally — `node_modules` not installed.)

## Out of scope

The separate **performance** workflow fails earlier at `pnpm build` with `Error: Configuration must contain projectId` (a missing CI env/secret), never reaching its test step. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change with no application code; restores intended test execution and may reveal existing test failures that were hidden.
> 
> **Overview**
> The **unit_integration** job’s “Test with coverage” step was always failing because it ran `pnpm run test:all -- --coverage`. **`test:all`** already invokes Jest with `--coverage --verbose`, so the extra `-- --coverage` was forwarded as a **positional test-path pattern**, Jest matched zero files, and the step exited with “No tests found” without running the suite.
> 
> The workflow now runs **`pnpm run test:all`** only, with an inline comment explaining the pnpm/Jest argument behavior. Coverage upload is unchanged; the job should actually execute tests (and may surface real failures that were previously masked).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0033a22f7ae34112e3fd0ce9d7cb06c2720d1534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->