### PR TITLE
test: fix suite load/import errors surfaced by the jest fix

### DIFF
--- a/jest.json
+++ b/jest.json
@@ -42,6 +42,7 @@
     "^constants/(.*)$": "<rootDir>/src/constants/$1",
     "^pages/(.*)$": "<rootDir>/src/pages/$1",
     "^api/(.*)$": "<rootDir>/src/pages/api/$1",
+    "^i18n/(.*)$": "<rootDir>/src/i18n/$1",
     "^src/(.*)$": "<rootDir>/src/$1"
   },
   "collectCoverageFrom": [

--- a/src/__tests__/components/StrategyRow.spec.tsx
+++ b/src/__tests__/components/StrategyRow.spec.tsx
@@ -33,6 +33,13 @@ jest.mock("wagmi", () => ({
     address: "0x1234567890123456789012345678901234567890",
     isConnected: true,
   }),
+  usePublicClient: () => ({
+    chain: { id: 1, name: "Ethereum" },
+    getBalance: jest.fn(),
+    readContract: jest.fn(),
+  }),
+  useWalletClient: () => ({ data: undefined }),
+  createConnector: (createConnectorFn: any) => createConnectorFn,
 }))
 
 const renderWithTheme = (component: React.ReactElement) => {

--- a/src/__tests__/integration/app.spec.ts
+++ b/src/__tests__/integration/app.spec.ts
@@ -30,6 +30,7 @@ jest.mock("wagmi", () => ({
   useSwitchChain: () => ({
     switchChainAsync: jest.fn(),
   }),
+  createConnector: (createConnectorFn: any) => createConnectorFn,
   WagmiProvider: ({ children }: { children: React.ReactNode }) =>
     ({ children } as any),
 }))

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -31,11 +31,14 @@ jest.mock("next/router", () => ({
 
 // Mock wagmi hooks
 jest.mock("wagmi", () => ({
-  useAccount: () => ({
+  // jest.fn so tests can override per-case via (useAccount as jest.Mock).mockReturnValue(...)
+  useAccount: jest.fn(() => ({
     address: "0x1234567890123456789012345678901234567890",
     isConnected: true,
     chain: { id: 1, name: "Ethereum" },
-  }),
+  })),
+  // wagmi v2 connector factory; some setup/provider code imports this.
+  createConnector: (createConnectorFn: any) => createConnectorFn,
   usePublicClient: () => ({
     chain: { id: 1, name: "Ethereum" },
     getBalance: jest.fn(),
@@ -82,15 +85,18 @@ process.env.NEXT_PUBLIC_INFURA_API_KEY = "test-infura-key"
 process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID =
   "test-walletconnect-id"
 
-// Mock window.ethereum
-Object.defineProperty(window, "ethereum", {
-  value: {
-    request: jest.fn(),
-    on: jest.fn(),
-    removeListener: jest.fn(),
-  },
-  writable: true,
-})
+// Mock window.ethereum (guard for node-environment test files, e.g. API route
+// tests that declare `@jest-environment node` and have no `window`).
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "ethereum", {
+    value: {
+      request: jest.fn(),
+      on: jest.fn(),
+      removeListener: jest.fn(),
+    },
+    writable: true,
+  })
+}
 
 // Mock fetch: provide minimal Response-like object when tests don't override
 global.fetch = jest

--- a/src/hooks/wagmi-helper/useWaitForTransactions.ts
+++ b/src/hooks/wagmi-helper/useWaitForTransactions.ts
@@ -87,7 +87,7 @@ export const useWaitForTransaction = ({
         }
         return { data: receipt, error: undefined }
       } catch (error_) {
-        const error = <Error>error_
+        const error = error_ as Error
         if (!didCancel) {
           setState((x) => ({ ...x, error, loading: false }))
         }


### PR DESCRIPTION
## Context

Follow-up to #1912, which fixed the jest invocation so `unit_integration` actually runs the suite. That exposed that **6 suites failed to even load** (stale mocks + one source-parse issue). This PR fixes the **load-level** problems so the suites run.

## Changes

| File | Fix |
|---|---|
| `src/hooks/wagmi-helper/useWaitForTransactions.ts` | `<Error>x` angle-bracket cast → `x as Error`. babel-jest (unlike Next/SWC) can't parse angle-bracket casts, so the file failed to transform. Behaviour identical. |
| `src/__tests__/setup.ts` | wagmi mock: `useAccount` → `jest.fn` (tests override via `mockReturnValue`); add v2 `createConnector`. Guard `window.ethereum` with `typeof window` so `@jest-environment node` suites stop throwing `window is not defined`. |
| `jest.json` | add `^i18n/(.*)$` moduleNameMapper so `i18n/*` imports resolve. |
| `StrategyRow.spec.tsx`, `app.spec.ts` | complete their inline wagmi mocks (`usePublicClient`, `createConnector`) so the suites load. |

## Resolved (load/import/transform errors)

`createConnector is not a function`, `mockUseAccount.mockReturnValue is not a function`, `usePublicClient is not a function`, `window is not defined`, `Cannot find module 'i18n/alphaSteth'`, and the `useWaitForTransactions.ts` parse error.

## Explicitly NOT in scope (tracked follow-up)

Now that the suites **run**, some component tests fail at the **render level** (`Element type is invalid`, etc.) — genuine stale-test rehab. Also, `analytics-server.test.ts` imports `node-mocks-http`, which **isn't in `package.json`** (needs a dependency decision). These are deliberately left for a separate effort.

CI note: `unit_integration` will still be red until the render-level rehab lands; per branch protection these checks are not required for merge, and this PR strictly reduces the failure surface (suites load instead of erroring on import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and mock changes plus a syntax-equivalent cast in a wagmi helper; no production behavior or security-sensitive logic changes.
> 
> **Overview**
> Unblocks Jest from failing at **import/transform** time (follow-up to getting `unit_integration` to actually run the suite). Six suites that previously could not load should now parse and initialize.
> 
> **Jest config:** Adds `^i18n/(.*)$` to `moduleNameMapper` so imports like `i18n/alphaSteth` resolve under Jest.
> 
> **Source (babel-jest only):** In `useWaitForTransactions.ts`, replaces an angle-bracket `Error` cast with `as Error` so babel-jest can transform the file; runtime behavior is unchanged.
> 
> **Global test setup (`setup.ts`):** Wraps `useAccount` in `jest.fn` so tests can override with `mockReturnValue`; adds wagmi v2 `createConnector` to the mock; only defines `window.ethereum` when `window` exists (fixes `@jest-environment node` suites).
> 
> **Per-suite wagmi mocks:** `StrategyRow.spec.tsx` and `app.spec.ts` extend inline `wagmi` mocks with `usePublicClient`, `useWalletClient`, and `createConnector` so those files load.
> 
> Render-level failures and missing deps (e.g. `node-mocks-http`) are explicitly out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68c76f4694b2c0edb80c4a6df83b0e4281ec4709. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->